### PR TITLE
Fix #28, Opaque CFE_SB_MsgId_t values

### DIFF
--- a/fsw/platform_inc/to_lab_sub_table.h
+++ b/fsw/platform_inc/to_lab_sub_table.h
@@ -50,10 +50,10 @@
 static TO_subscription_t  TO_SubTable[] =
 {
             /* CFS App Subscriptions */
-            {TO_LAB_HK_TLM_MID,     {0,0},  4},
-            {TO_LAB_DATA_TYPES_MID, {0,0},  4},
-            {CI_LAB_HK_TLM_MID,     {0,0},  4},
-            {SAMPLE_APP_HK_TLM_MID, {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_HK_TLM_MID),     {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_DATA_TYPES_MID), {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_HK_TLM_MID),     {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_HK_TLM_MID), {0,0},  4},
 
 #if 0
             /* Add these if needed */
@@ -65,18 +65,18 @@ static TO_subscription_t  TO_SubTable[] =
 #endif
 
             /* cFE Core subscriptions */
-            {CFE_ES_HK_TLM_MID,          {0,0},  4},
-            {CFE_EVS_HK_TLM_MID,         {0,0},  4},
-            {CFE_SB_HK_TLM_MID,          {0,0},  4},
-            {CFE_TBL_HK_TLM_MID,         {0,0},  4},
-            {CFE_TIME_HK_TLM_MID,        {0,0},  4},
-            {CFE_TIME_DIAG_TLM_MID,      {0,0},  4},
-            {CFE_SB_STATS_TLM_MID,       {0,0},  4},
-            {CFE_TBL_REG_TLM_MID,        {0,0},  4},
-            {CFE_EVS_LONG_EVENT_MSG_MID, {0,0}, 32},
-            {CFE_ES_SHELL_TLM_MID,       {0,0}, 32},
-            {CFE_ES_APP_TLM_MID,         {0,0},  4},
-            {CFE_ES_MEMSTATS_TLM_MID,    {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_HK_TLM_MID),          {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_HK_TLM_MID),         {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_HK_TLM_MID),          {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_HK_TLM_MID),         {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_HK_TLM_MID),        {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_DIAG_TLM_MID),      {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_STATS_TLM_MID),       {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_REG_TLM_MID),        {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID), {0,0}, 32},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SHELL_TLM_MID),       {0,0}, 32},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_APP_TLM_MID),         {0,0},  4},
+            {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_MEMSTATS_TLM_MID),    {0,0},  4},
 
             {TO_UNUSED,              {0,0},  0},
             {TO_UNUSED,              {0,0},  0},

--- a/fsw/src/to_lab_app.h
+++ b/fsw/src/to_lab_app.h
@@ -47,7 +47,7 @@
 /*****************************************************************************/
 
 #define TO_TASK_MSEC             500          /* run at 2 Hz */
-#define TO_UNUSED                  0
+#define TO_UNUSED                CFE_SB_MSGID_RESERVED
 
 #define cfgTLM_ADDR "192.168.1.81"
 #define cfgTLM_PORT 1235


### PR DESCRIPTION
**Describe the contribution**
Apply the `CFE_SB_MsgIdToValue()` and `CFE_SB_ValueToMsgId()` routines where compatibility with an integer MsgId is necessary - syslog prints, events, compile-time MID `#define` values.

Fixes #28 

**Testing performed**
Unit test
Execute CFE and sanity-check normal operation - send commands to app using `cmdUtil` and confirm commands are processed normally.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 18.04 LTS, 64-bit

**Additional context**
In future versions of CFE SB the MsgId type might not be a simple integer, so this is one step in the direction of avoiding this assumption in apps.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.