### PR TITLE
Fix #30, Resolve doxygen warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This lab application is a non-flight utility to downlink telemetry from the cFS 
 
 to_lab is a simple telemetry downlink application that sends CCSDS telecommand packets over a UDP/IP port. The UDP port and IP address are specified in the "Enable Telemetry" command.  It does not provide a full CCSDS Telecommand stack implementation.
 
-To send telemtry to the "ground" or UDP/IP port, edit the subscription table in the platform include file: build/<cpuX>/inc/to_lab_sub_table.h.  to_lab will subscribe to the packet IDs that are listed in this table and send the telemetry packets it receives to the UDP/IP port.
+To send telemtry to the "ground" or UDP/IP port, edit the subscription table in the platform include file: build/\<cpuX\>/inc/to_lab_sub_table.h.  to_lab will subscribe to the packet IDs that are listed in this table and send the telemetry packets it receives to the UDP/IP port.
 
 ## Version Notes
 - 2.3.2 DEVELOPMENT

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This lab application is a non-flight utility to downlink telemetry from the cFS 
 
 to_lab is a simple telemetry downlink application that sends CCSDS telecommand packets over a UDP/IP port. The UDP port and IP address are specified in the "Enable Telemetry" command.  It does not provide a full CCSDS Telecommand stack implementation.
 
-To send telemtry to the "ground" or UDP/IP port, edit the subscription table in the platform include file: build/\<cpuX\>/inc/to_lab_sub_table.h.  to_lab will subscribe to the packet IDs that are listed in this table and send the telemetry packets it receives to the UDP/IP port.
+To send telemtry to the "ground" or UDP/IP port, edit the subscription table in the platform include file: fsw/platform_inc/to_lab_sub_table.h.  to_lab will subscribe to the packet IDs that are listed in this table and send the telemetry packets it receives to the UDP/IP port.
 
 ## Version Notes
 - 2.3.2 DEVELOPMENT


### PR DESCRIPTION
**Describe the contribution**
Fix #30 
Resolve doxygen warnings

**Testing performed**
Steps taken to test the contribution:

1. Corrected line(s) that generated warnings
2. Rebuilt documentation with `make doc`
3. Observed no warnings generated
4. Viewed relevant page(s) to verify correctness

**Expected behavior changes**
Changes to documentation only; no code impact

**Contributor Info - All information REQUIRED for consideration of pull request**
Leor Bleier, NASA\GSFC
