### PR TITLE
Fix #34, Deprecate shell tlm subscription

### DIFF
--- a/fsw/platform_inc/to_lab_sub_table.h
+++ b/fsw/platform_inc/to_lab_sub_table.h
@@ -74,7 +74,11 @@ static TO_subscription_t  TO_SubTable[] =
             {CFE_SB_STATS_TLM_MID,       {0,0},  4},
             {CFE_TBL_REG_TLM_MID,        {0,0},  4},
             {CFE_EVS_LONG_EVENT_MSG_MID, {0,0}, 32},
+
+#ifndef CFE_OMIT_DEPRECATED_6_7
             {CFE_ES_SHELL_TLM_MID,       {0,0}, 32},
+#endif
+
             {CFE_ES_APP_TLM_MID,         {0,0},  4},
             {CFE_ES_MEMSTATS_TLM_MID,    {0,0},  4},
 


### PR DESCRIPTION
**Describe the contribution**
Fix #34 
Deprecates shell tlm subscription

**Testing performed**
Just build and unit test per nasa/cfe#645

**Expected behavior changes**
No shell output telemetry

**System(s) tested on**
 - Hardware: cFS Dev Server 3
 - OS: Ubuntu 18.04
 - Versions: See nasa/cFE#645

**Additional context**
See nasa/cFE#643

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC