### PR TITLE
Fix #36, Use OS_MAX_QUEUE_DEPTH rather than 64.

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -174,9 +174,9 @@ void TO_LAB_init(void)
 
     CFE_ES_RegisterApp();
     TO_LAB_Global.downlink_on = false;
-    PipeDepth = 8;
+    PipeDepth = TO_LAB_CMD_PIPE_DEPTH;
     strcpy(PipeName,  "TO_LAB_CMD_PIPE");
-    ToTlmPipeDepth = 64;
+    ToTlmPipeDepth = TO_LAB_TLM_PIPE_DEPTH;
     strcpy(ToTlmPipeName,  "TO_LAB_TLM_PIPE");
 
     /*

--- a/fsw/src/to_lab_app.h
+++ b/fsw/src/to_lab_app.h
@@ -49,6 +49,16 @@
 #define TO_TASK_MSEC             500          /* run at 2 Hz */
 #define TO_UNUSED                  0
 
+/**
+ * Depth of pipe for commands to the TO_LAB application itself
+ */
+#define TO_LAB_CMD_PIPE_DEPTH       8
+
+/**
+ * Depth of pipe for telemetry forwarded through the TO_LAB application
+ */
+#define TO_LAB_TLM_PIPE_DEPTH       OS_QUEUE_MAX_DEPTH
+
 #define cfgTLM_ADDR "192.168.1.81"
 #define cfgTLM_PORT 1235
 #define TO_LAB_VERSION_NUM "5.1.0"


### PR DESCRIPTION
**Describe the contribution**
Configure the maximum depth supported by OSAL, rather than a hard coded 64.

Fixes #36 

**Testing performed**
Build with default config.  Confirm normal operation of TO_LAB on system with max queue depth set to 50.

**Expected behavior changes**
None, except on systems where supported queue depth is less than 64.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
