### PR TITLE
Fix #41, remove dependencies on CCSDS types

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -100,7 +100,7 @@ int32 TO_LAB_RemoveAll(const TO_LAB_RemoveAll_t *data);
 int32 TO_LAB_RemovePacket(const TO_LAB_RemovePacket_t *data);
 int32 TO_LAB_ResetCounters(const TO_LAB_ResetCounters_t *data);
 int32 TO_LAB_SendDataTypes(const TO_LAB_SendDataTypes_t *data);
-int32 TO_LAB_SendHousekeeping(const CCSDS_CommandPacket_t *data);
+int32 TO_LAB_SendHousekeeping(const CFE_SB_CmdHdr_t *data);
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                   */
@@ -273,7 +273,7 @@ void TO_LAB_process_commands(void)
                         break;
 
                     case TO_LAB_SEND_HK_MID:
-                        TO_LAB_SendHousekeeping((const CCSDS_CommandPacket_t *)MsgPtr);
+                        TO_LAB_SendHousekeeping((const CFE_SB_CmdHdr_t *)MsgPtr);
                         break;
 
                     default:
@@ -417,7 +417,7 @@ int32 TO_LAB_SendDataTypes(const TO_LAB_SendDataTypes_t *data)
 /* TO_LAB_SendHousekeeping() -- HK status                          */
 /* Does not increment CommandCounter                               */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 TO_LAB_SendHousekeeping(const CCSDS_CommandPacket_t *data)
+int32 TO_LAB_SendHousekeeping(const CFE_SB_CmdHdr_t *data)
 {
     CFE_SB_TimeStampMsg(&TO_LAB_Global.HkBuf.MsgHdr);
     CFE_SB_SendMsg(&TO_LAB_Global.HkBuf.MsgHdr);


### PR DESCRIPTION
**Describe the contribution**
Replace references to `ccsds.h` types with the `cfe_sb.h`-provided type. 

Fixes #41

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
