### PR TITLE
fix #47 - correct return type for TO_LAB_init()

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -155,7 +155,7 @@ void TO_delete_callback(void)
 /* TO_init() -- TO initialization                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int TO_LAB_init(void)
+int32 TO_LAB_init(void)
 {
     int32  status;
     char   PipeName[16];


### PR DESCRIPTION
**Describe the contribution**
Fixes #47 
Corrects return value of TO_LAB_init() to be int32 not int.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov