### PR TITLE
Fix #50, Mark end of valid MsgId subscriptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.6.4)
 project(CFS_TO_LAB C)
 
+# Include source directory for table use
+include_directories(fsw/src)
+
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 include_directories(${ci_lab_MISSION_DIR}/fsw/platform_inc)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To send telemtry to the "ground" or UDP/IP port, edit the subscription table in 
 - Fix for a clean build with OMIT_DEPRECATED
 - Minor updates (see <https://github.com/nasa/to_lab/pull/26>)
 
-### _**OFFICIAL RELEASE: 2.3.0**_
+### _**OFFICIAL RELEASE: 2.3.0 - Aquila**_
 
 - Minor updates (see <https://github.com/nasa/to_lab/pull/13>)
 

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -227,9 +227,16 @@ int TO_LAB_init(void)
     /* Subscriptions for TLM pipe*/
     for (i = 0; (i < (sizeof(TO_LAB_Subs->Subs) / sizeof(TO_LAB_Subs->Subs[0]))); i++)
     {
-        if (CFE_SB_IsValidMsgId(TO_LAB_Subs->Subs[i].Stream))
+        if (CFE_SB_MsgIdToValue(TO_LAB_Subs->Subs[i].Stream) == TO_UNUSED)
+        {
+            /* Only process until MsgId TO_UNUSED is found*/
+            break;
+        }
+        else if (CFE_SB_IsValidMsgId(TO_LAB_Subs->Subs[i].Stream))
+        {
             status = CFE_SB_SubscribeEx(TO_LAB_Subs->Subs[i].Stream, TO_LAB_Global.Tlm_pipe, TO_LAB_Subs->Subs[i].Flags,
                                         TO_LAB_Subs->Subs[i].BufLimit);
+        }
 
         if (status != CFE_SUCCESS)
             CFE_EVS_SendEvent(TO_SUBSCRIBE_ERR_EID, CFE_EVS_EventType_ERROR,

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -227,7 +227,7 @@ int TO_LAB_init(void)
     /* Subscriptions for TLM pipe*/
     for (i = 0; (i < (sizeof(TO_LAB_Subs->Subs) / sizeof(TO_LAB_Subs->Subs[0]))); i++)
     {
-        if (CFE_SB_MsgIdToValue(TO_LAB_Subs->Subs[i].Stream) == TO_UNUSED)
+        if (CFE_SB_MsgId_Equal(TO_LAB_Subs->Subs[i].Stream, TO_UNUSED))
         {
             /* Only process until MsgId TO_UNUSED is found*/
             break;

--- a/fsw/tables/to_lab_sub.c
+++ b/fsw/tables/to_lab_sub.c
@@ -30,6 +30,7 @@
 #include "cfe_tbl_filedef.h"  /* Required to obtain the CFE_TBL_FILEDEF macro definition */
 
 #include "to_lab_sub_table.h"
+#include "to_lab_app.h"
 
 /*
 ** Add the proper include file for the message IDs below
@@ -86,7 +87,10 @@ TO_LAB_Subs_t TO_LAB_Subs =
     #endif
 
         {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_APP_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_MEMSTATS_TLM_MID), {0, 0}, 4}
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_MEMSTATS_TLM_MID), {0, 0}, 4},
+
+        /* TO_UNUSED entry to mark the end of valid MsgIds */
+        {TO_UNUSED, {0, 0}, 0}
     }
 };
 


### PR DESCRIPTION
**Describe the contribution**
Fix #50 

- Added a TO_UNUSED entry at the end of the subscription list
- Added break in subscription loop when TO_UNUSED found

**Testing performed**
Normal run, confirmed no 0x0 duplicate subscription message, confirmed nominal hk telemetry still works with GroundSystem

**Expected behavior changes**
No more subscriptions on the unused table slots (no MsgId 0 subscriptions).

**System(s) tested on**
 - Hardware: cFS Dev 3
 - OS: Ubuntu 18.04
 - Versions: bundle

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC