### PR TITLE
Close #49, Add build number and baseline to version file

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -250,8 +250,7 @@ int32 TO_LAB_init(void)
     OS_TaskInstallDeleteHandler(&TO_delete_callback);
 
     CFE_EVS_SendEvent(TO_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
-                      "TO Lab Initialized. Version %d.%d.%d.%d Awaiting enable command.", TO_LAB_MAJOR_VERSION,
-                      TO_LAB_MINOR_VERSION, TO_LAB_REVISION, TO_LAB_MISSION_REV);
+                      "TO Lab Initialized.%s, Awaiting enable command.", TO_LAB_VERSION_STRING);
 
     return CFE_SUCCESS;
 } /* End of TO_LAB_init() */

--- a/fsw/src/to_lab_version.h
+++ b/fsw/src/to_lab_version.h
@@ -18,23 +18,47 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: to_lab_version.h
-**
-** Purpose:
-**  The TO Lab Application header file containing version number
-**
-** Notes:
-**
 *************************************************************************/
-#ifndef _to_lab_version_h_
-#define _to_lab_version_h_
+#ifndef TO_LAB_VERSION_H
+#define TO_LAB_VERSION_H
 
-#define TO_LAB_MAJOR_VERSION 2
-#define TO_LAB_MINOR_VERSION 3
-#define TO_LAB_REVISION      7
-#define TO_LAB_MISSION_REV   0
+/*! @file to_lab_version.h
+ * @brief Purpose: 
+ * 
+ *  The TO Lab Application header file containing version information
+ * 
+ */
 
-#endif /* _to_lab_version_h_ */
+/* Development Build Macro Definitions */
+#define TO_LAB_BUILD_NUMBER 43 /*!< Development Build: Number of commits since baseline */
+#define TO_LAB_BUILD_BASELINE "v2.3.0" /*!< Development Build: git tag that is the base for the current development */
+
+/* Version Macro Definitions */
+
+#define TO_LAB_MAJOR_VERSION 2 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
+#define TO_LAB_MINOR_VERSION 3 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
+#define TO_LAB_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
+#define TO_LAB_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+
+#define TO_LAB_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
+#define TO_LAB_STR(x)        TO_LAB_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
+
+/*! @brief Development Build Version Number. 
+ * @details Baseline git tag + Number of commits since baseline. @n
+ * See @ref cfsversions for format differences between development and release versions.
+ */
+#define TO_LAB_VERSION TO_LAB_BUILD_BASELINE "+dev" TO_LAB_STR(TO_LAB_BUILD_NUMBER) 
+
+/*! @brief Development Build Version String.
+ * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest official version. @n
+ * See @ref cfsversions for format differences between development and release versions. 
+*/          
+#define TO_LAB_VERSION_STRING                                                          \
+    " TO Lab Development Build "                                                     \
+    TO_LAB_VERSION                                                                     \
+    ", Last Official Release: v2.3.0"   /* For full support please use this version */
+
+#endif /* TO_LAB_VERSION_H */
 
 /************************/
 /*  End of File Comment */


### PR DESCRIPTION
**Describe the contribution**
Close #49

**Testing performed**
Built bundle and confirmed TO_LAB reports development version.

**Expected behavior changes**
Version report now uses the version string. See excerpt from cfs log:

```
EVS Port1 42/1/TO_LAB_APP 1: TO Lab Initialized. TO Lab Development Build v2.3.0+dev43, Last Official Release: v2.3.0, Awaiting enable command.
```

**System(s) tested on**
Ubuntu Docker on Mac OS X

**Additional context**
Add any other context about the contribution here.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC