### PR TITLE
Fix #56, Add header guard to to_lab_sub_table.h

### DIFF
--- a/fsw/platform_inc/to_lab_sub_table.h
+++ b/fsw/platform_inc/to_lab_sub_table.h
@@ -26,6 +26,8 @@
 ** Notes:
 **
 *************************************************************************/
+#ifndef to_lab_sub_table_h_
+#define to_lab_sub_table_h_
 
 #include "cfe_msgids.h"
 #include "cfe_platform_cfg.h"
@@ -43,3 +45,5 @@ typedef struct
     TO_LAB_Sub_t Subs[CFE_PLATFORM_SB_MAX_MSG_IDS];
 }
 TO_LAB_Subs_t;
+
+#endif /* to_lab_sub_table_h_ */


### PR DESCRIPTION
**Describe the contribution**
Fix #56 - add header guard to to_lab_sub_table.h

**Testing performed**
Build and run - no issues

**Expected behavior changes**
No impact to behavior, good design practice

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main (+ cfe/osal main) + this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC