### PR TITLE
Integration Candidate: 2020-08-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ To send telemtry to the "ground" or UDP/IP port, edit the subscription table in 
 
 ## Version History
 
+### Development Build: 2.4.0-rc1+dev6
+
+- Adds header guard to `to_lab_sub_table.h`
+- See <https://github.com/nasa/to_lab/pull/59>
+
 ### Development Build: 2.4.0-rc1+dev3
 
 - Remove reference to deprecated `CFE_ES_SHELL_TLM_MID`.

--- a/fsw/platform_inc/to_lab_sub_table.h
+++ b/fsw/platform_inc/to_lab_sub_table.h
@@ -26,6 +26,8 @@
 ** Notes:
 **
 *************************************************************************/
+#ifndef to_lab_sub_table_h_
+#define to_lab_sub_table_h_
 
 #include "cfe_msgids.h"
 #include "cfe_platform_cfg.h"
@@ -43,3 +45,5 @@ typedef struct
     TO_LAB_Sub_t Subs[CFE_PLATFORM_SB_MAX_MSG_IDS];
 }
 TO_LAB_Subs_t;
+
+#endif /* to_lab_sub_table_h_ */

--- a/fsw/src/to_lab_version.h
+++ b/fsw/src/to_lab_version.h
@@ -30,7 +30,7 @@
  */
 
 /* Development Build Macro Definitions */
-#define TO_LAB_BUILD_NUMBER 3 /*!< Development Build: Number of commits since baseline */
+#define TO_LAB_BUILD_NUMBER 6 /*!< Development Build: Number of commits since baseline */
 #define TO_LAB_BUILD_BASELINE "v2.4.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */


### PR DESCRIPTION
**Describe the contribution**
Fix #56 

**Testing performed**
Bundle CI - https://github.com/nasa/cFS/pull/134/checks

**Expected behavior changes**
PR #57 - Adds header guard to` to_lab_sub_table.h`

**System(s) tested on**
Ubuntu - CI

**Additional context**
https://github.com/nasa/cFS/pull/134

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman, NASA-GSFC
