### PR TITLE
Fix #60, Update TO to use osal_id_t

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -54,7 +54,7 @@ typedef struct
 {
     CFE_SB_PipeId_t Tlm_pipe;
     CFE_SB_PipeId_t Cmd_pipe;
-    uint32          TLMsockid;
+    osal_id_t       TLMsockid;
     bool            downlink_on;
     char            tlm_dest_IP[17];
     bool            suppress_sendto;


### PR DESCRIPTION
**Describe the contribution**
Update the TLMsockid field to be `osal_id_t` instead of `uint32`

Fixes #60 

**Testing performed**
Build and sanity test CFE

**Expected behavior changes**
None.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This makes it consistent with other modules

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
