### PR TITLE
Fix #66, Implement message alignment pattern

### DIFF
--- a/fsw/platform_inc/to_lab_sub_table.h
+++ b/fsw/platform_inc/to_lab_sub_table.h
@@ -43,7 +43,6 @@ typedef struct
 typedef struct
 {
     TO_LAB_Sub_t Subs[CFE_PLATFORM_SB_MAX_MSG_IDS];
-}
-TO_LAB_Subs_t;
+} TO_LAB_Subs_t;
 
 #endif /* to_lab_sub_table_h_ */

--- a/fsw/src/to_lab_msg.h
+++ b/fsw/src/to_lab_msg.h
@@ -48,11 +48,9 @@ typedef struct
 
 typedef struct
 {
-    CFE_SB_TlmHdr_t        TlmHeader;
-    TO_LAB_HkTlm_Payload_t Payload;
+    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry header */
+    TO_LAB_HkTlm_Payload_t    Payload;   /**< \brief Telemetry payload */
 } TO_LAB_HkTlm_t;
-
-#define TO_HK_TLM_LNGTH sizeof(TO_LAB_HkTlm_t)
 
 /******************************************************************************/
 
@@ -80,18 +78,15 @@ typedef struct
 
 typedef struct
 {
-    CFE_SB_TlmHdr_t            TlmHeader;
-    TO_LAB_DataTypes_Payload_t Payload;
+    CFE_MSG_TelemetryHeader_t  TlmHeader; /**< \brief Telemetry header */
+    TO_LAB_DataTypes_Payload_t Payload;   /**< \brief Telemetry payload */
 } TO_LAB_DataTypesTlm_t;
-
-#define TO_DATA_TYPES_LNGTH sizeof(TO_LAB_DataTypes_t)
 
 /******************************************************************************/
 
 typedef struct
 {
-    uint8 CmdHeader[CFE_SB_CMD_HDR_SIZE];
-
+    CFE_MSG_CommandHeader_t CmdHeade; /**< \brief Command header */
 } TO_LAB_NoArgsCmd_t;
 
 /*
@@ -101,10 +96,10 @@ typedef struct
  *
  * This matches the pattern in CFE core and other modules.
  */
-typedef TO_LAB_NoArgsCmd_t TO_LAB_Noop_t;
-typedef TO_LAB_NoArgsCmd_t TO_LAB_ResetCounters_t;
-typedef TO_LAB_NoArgsCmd_t TO_LAB_RemoveAll_t;
-typedef TO_LAB_NoArgsCmd_t TO_LAB_SendDataTypes_t;
+typedef TO_LAB_NoArgsCmd_t TO_LAB_NoopCmd_t;
+typedef TO_LAB_NoArgsCmd_t TO_LAB_ResetCountersCmd_t;
+typedef TO_LAB_NoArgsCmd_t TO_LAB_RemoveAllCmd_t;
+typedef TO_LAB_NoArgsCmd_t TO_LAB_SendDataTypesCmd_t;
 
 typedef struct
 {
@@ -116,9 +111,9 @@ typedef struct
 
 typedef struct
 {
-    uint8                      CmdHeader[CFE_SB_CMD_HDR_SIZE];
-    TO_LAB_AddPacket_Payload_t Payload;
-} TO_LAB_AddPacket_t;
+    CFE_MSG_CommandHeader_t    CmdHeader; /**< \brief Command header */
+    TO_LAB_AddPacket_Payload_t Payload;   /**< \brief Command payload */
+} TO_LAB_AddPacketCmd_t;
 
 /*****************************************************************************/
 
@@ -138,9 +133,9 @@ typedef struct
 
 typedef struct
 {
-    uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-    TO_LAB_RemovePacket_Payload_t Payload;
-} TO_LAB_RemovePacket_t;
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    TO_LAB_RemovePacket_Payload_t Payload;   /**< \brief Command paylod */
+} TO_LAB_RemovePacketCmd_t;
 
 /******************************************************************************/
 
@@ -151,9 +146,9 @@ typedef struct
 
 typedef struct
 {
-    uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-    TO_LAB_EnableOutput_Payload_t Payload;
-} TO_LAB_EnableOutput_t;
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    TO_LAB_EnableOutput_Payload_t Payload;   /**< \brief Command payload */
+} TO_LAB_EnableOutputCmd_t;
 
 /******************************************************************************/
 

--- a/fsw/tables/to_lab_sub.c
+++ b/fsw/tables/to_lab_sub.c
@@ -27,7 +27,7 @@
 **
 *************************************************************************/
 
-#include "cfe_tbl_filedef.h"  /* Required to obtain the CFE_TBL_FILEDEF macro definition */
+#include "cfe_tbl_filedef.h" /* Required to obtain the CFE_TBL_FILEDEF macro definition */
 
 #include "to_lab_sub_table.h"
 #include "to_lab_app.h"
@@ -52,42 +52,36 @@
 #include "lc_msgids.h"
 #endif
 
-TO_LAB_Subs_t TO_LAB_Subs =
-{
-    .Subs =
-    {
-        /* CFS App Subscriptions */
-        {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_HK_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_DATA_TYPES_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_HK_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_HK_TLM_MID), {0, 0}, 4},
+TO_LAB_Subs_t TO_LAB_Subs = {.Subs = {/* CFS App Subscriptions */
+                                      {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_DATA_TYPES_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_HK_TLM_MID), {0, 0}, 4},
 
-    #if 0
+#if 0
         /* Add these if needed */
         {CFE_SB_MSGID_WRAP_VALUE(HS_HK_TLM_MID), {0,0}, 4},
         {CFE_SB_MSGID_WRAP_VALUE(FM_HK_TLM_MID), {0,0}, 4},
         {CFE_SB_MSGID_WRAP_VALUE(SC_HK_TLM_MID), {0,0}, 4},
         {CFE_SB_MSGID_WRAP_VALUE(DS_HK_TLM_MID), {0,0}, 4},
         {CFE_SB_MSGID_WRAP_VALUE(LC_HK_TLM_MID), {0,0}, 4},
-    #endif
+#endif
 
-        /* cFE Core subscriptions */
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_HK_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_HK_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_HK_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_HK_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_HK_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_DIAG_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_STATS_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_REG_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID), {0, 0}, 32},
+                                      /* cFE Core subscriptions */
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_HK_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_DIAG_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_STATS_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_REG_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID), {0, 0}, 32},
 
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_APP_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_MEMSTATS_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_APP_TLM_MID), {0, 0}, 4},
+                                      {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_MEMSTATS_TLM_MID), {0, 0}, 4},
 
-        /* TO_UNUSED entry to mark the end of valid MsgIds */
-        {TO_UNUSED, {0, 0}, 0}
-    }
-};
+                                      /* TO_UNUSED entry to mark the end of valid MsgIds */
+                                      {TO_UNUSED, {0, 0}, 0}}};
 
 CFE_TBL_FILEDEF(TO_LAB_Subs, TO_LAB_APP.TO_LAB_Subs, TO Lab Sub Tbl, to_lab_sub.tbl)


### PR DESCRIPTION
**Describe the contribution**
Fix #66
- Replace CFE_SB_RcvMsg with CFE_SB_ReceiveBuffer
- Use CFE_SB_Buffer_t for receiving and casting to command types
- Use CFE_MSG_CommandHeader_t and CFE_MSG_TelemetryHeader_t in
  command and telemetry type definitions
- Use CFE_SB_TransmitMsg to copy the command and telemetry
  into a CFE_SB_Buffer_t and send it where needed
- Avoids need to create send buffers within the app (or union
  the packet types with CFE_SB_Buffer_t)
- Eliminates references to CFE_SB_CmdHdr_t and CFE_SB_TlmHdr_t
  that formerly enforced alignment since these had potential
  to change the actual packet sizes
- No need to cast to CFE_MSG_Message_t anywhere since it's
  available in the CFE_SB_Buffer_t union
- Replaced CFE_MSG_Size_t with size_t

**Testing performed**
Bundle CI, unit tests, spot checked cmd/tlm

**Expected behavior changes**
None, applied pattern

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle integration-candidate + nasa/cFE#1015 + this commit

**Additional context**
Depends on nasa/cFE#1015

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC