### PR TITLE
Fix #90, Use cfe.h header file

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -34,7 +34,6 @@
 #include "to_lab_perfids.h"
 #include "to_lab_version.h"
 #include "to_lab_sub_table.h"
-#include "cfe_msg_api.h"
 
 /*
 ** Global Data Section

--- a/fsw/src/to_lab_app.h
+++ b/fsw/src/to_lab_app.h
@@ -30,13 +30,7 @@
 #ifndef _to_lab_app_h_
 #define _to_lab_app_h_
 
-#include "cfe_error.h"
-#include "cfe_sb.h"
-#include "cfe_time.h"
-#include "cfe_evs.h"
-#include "cfe_sb.h"
-#include "cfe_es.h"
-#include "cfe_tbl.h"
+#include "cfe.h"
 
 #include <errno.h>
 #include <string.h>


### PR DESCRIPTION
**Describe the contribution**
Replaces individual includes with the all-inclusive "cfe.h" header.

Fixes #90

**Testing performed**
Build and sanity check CFE along with reorg in nasa/cfe#1203

**Expected behavior changes**
Fixes dependency on `cfe_msg_api.h`

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Required for nasa/cfe#1203

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
