### PR TITLE
to_lab Integration candidate: 2021-03-30

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ To send telemtry to the "ground" or UDP/IP port, edit the subscription table in 
 
 ## Version History
 
+### Development Build: v2.4.0-rc1+dev47
+
+- Removes app registration call, `CFE_ES_RegisterApp()` since applications do not need to register themselves.
+- See <https://github.com/nasa/to_lab/pull/97>
+
 ### Development Build: v2.4.0-rc1+dev41
 
 -  Use `cfe.h` header file

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -151,7 +151,6 @@ int32 TO_LAB_init(void)
     char   ToTlmPipeName[16];
     uint16 ToTlmPipeDepth;
 
-    CFE_ES_RegisterApp();
     TO_LAB_Global.downlink_on = false;
     PipeDepth                 = TO_LAB_CMD_PIPE_DEPTH;
     strcpy(PipeName, "TO_LAB_CMD_PIPE");

--- a/fsw/src/to_lab_version.h
+++ b/fsw/src/to_lab_version.h
@@ -30,7 +30,7 @@
  */
 
 /* Development Build Macro Definitions */
-#define TO_LAB_BUILD_NUMBER 41 /*!< Development Build: Number of commits since baseline */
+#define TO_LAB_BUILD_NUMBER 47 /*!< Development Build: Number of commits since baseline */
 #define TO_LAB_BUILD_BASELINE \
     "v2.4.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 


### PR DESCRIPTION
## Describe the contribution

Fix #95, remove app registration 

## Testing 
to_lab checks <https://github.com/nasa/to_lab/pull/97/checks>
bundle checks <https://github.com/nasa/cFS/pull/227/checks>

## Expected behavior changes

### PR #95
Removes app registration call, `CFE_ES_RegisterApp()` since applications do not need to register themselves.

## Additional context
Part of <https://github.com/nasa/cFS/pull/227>

## Third party code
None

## Authors
@jphickey 
