### PR TITLE
Fix typos in .md, comments and event error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This lab application is a non-flight utility to downlink telemetry from the cFS 
 
 to_lab is a simple telemetry downlink application that sends CCSDS telecommand packets over a UDP/IP port. The UDP port and IP address are specified in the "Enable Telemetry" command. It does not provide a full CCSDS Telecommand stack implementation.
 
-To send telemtry to the "ground" or UDP/IP port, edit the subscription table in the platform include file: fsw/platform_inc/to_lab_sub_table.h. to_lab will subscribe to the packet IDs that are listed in this table and send the telemetry packets it receives to the UDP/IP port.
+To send telemetry to the "ground" or UDP/IP port, edit the subscription table in the platform include file: fsw/platform_inc/to_lab_sub_table.h. to_lab will subscribe to the packet IDs that are listed in this table and send the telemetry packets it receives to the UDP/IP port.
 
 ## Version History
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ To report a vulnerability for the to_lab subsystem please [submit an issue](http
 
 For general cFS vulnerabilities please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose) and see our [top-level security policy](https://github.com/nasa/cFS/security/policy) for additional information.
 
-In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
+In either case please use the "Bug Report" template and provide as much information as possible. Apply appropriate labels for each report. For security related reports, tag the issue with the "security" label.
 
 ## Testing
 

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -582,7 +582,7 @@ void TO_LAB_forward_telemetry(void)
             if (status < 0)
             {
                 CFE_EVS_SendEvent(TO_TLMOUTSTOP_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "L%d TO sendto error %d. Tlm output supressed\n", __LINE__, (int)status);
+                                  "L%d TO sendto error %d. Tlm output suppressed\n", __LINE__, (int)status);
                 TO_LAB_Global.suppress_sendto = true;
             }
         }

--- a/fsw/src/to_lab_msg.h
+++ b/fsw/src/to_lab_msg.h
@@ -134,7 +134,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
-    TO_LAB_RemovePacket_Payload_t Payload;   /**< \brief Command paylod */
+    TO_LAB_RemovePacket_Payload_t Payload;   /**< \brief Command payload */
 } TO_LAB_RemovePacketCmd_t;
 
 /******************************************************************************/


### PR DESCRIPTION
**Describe the contribution**
Fixed a few minor typos in the _text_ of:
- README.md
- SECURITY.md
  
...and in the _comments_ of:
- fsw/src/to_lab_msg.h
  
...and in an _event error message_ string of:
- fsw/src/to_lab_app.c
  
**Testing performed**
Only automated checks.

**Expected behavior changes**
None (minor Markdown doc, comments changes, and event error string changes that do not interact with any max lengths etc.).

**System(s) tested on**
n/a

**Additional context**
n/a

**Code contributions**
n/a