### PR TITLE
Fix #103, apply CFE_SB_ValueToMsgId where required

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -165,7 +165,8 @@ int32 TO_LAB_init(void)
     /*
     ** Initialize housekeeping packet (clear user data area)...
     */
-    CFE_MSG_Init(&TO_LAB_Global.HkTlm.TlmHeader.Msg, TO_LAB_HK_TLM_MID, sizeof(TO_LAB_Global.HkTlm));
+    CFE_MSG_Init(&TO_LAB_Global.HkTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(TO_LAB_HK_TLM_MID),
+                 sizeof(TO_LAB_Global.HkTlm));
 
     status = CFE_TBL_Register(&TO_SubTblHandle, "TO_LAB_Subs", sizeof(*TO_LAB_Subs), CFE_TBL_OPT_DEFAULT, NULL);
 
@@ -198,8 +199,8 @@ int32 TO_LAB_init(void)
     status = CFE_SB_CreatePipe(&TO_LAB_Global.Cmd_pipe, PipeDepth, PipeName);
     if (status == CFE_SUCCESS)
     {
-        CFE_SB_Subscribe(TO_LAB_CMD_MID, TO_LAB_Global.Cmd_pipe);
-        CFE_SB_Subscribe(TO_LAB_SEND_HK_MID, TO_LAB_Global.Cmd_pipe);
+        CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_CMD_MID), TO_LAB_Global.Cmd_pipe);
+        CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_SEND_HK_MID), TO_LAB_Global.Cmd_pipe);
     }
     else
         CFE_EVS_SendEvent(TO_CRCMDPIPE_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't create cmd pipe status %i",
@@ -216,9 +217,9 @@ int32 TO_LAB_init(void)
     /* Subscriptions for TLM pipe*/
     for (i = 0; (i < (sizeof(TO_LAB_Subs->Subs) / sizeof(TO_LAB_Subs->Subs[0]))); i++)
     {
-        if (CFE_SB_MsgId_Equal(TO_LAB_Subs->Subs[i].Stream, TO_UNUSED))
+        if (!CFE_SB_IsValidMsgId(TO_LAB_Subs->Subs[i].Stream))
         {
-            /* Only process until MsgId TO_UNUSED is found*/
+            /* Only process until invalid MsgId (aka TO_UNUSED) is found*/
             break;
         }
         else if (CFE_SB_IsValidMsgId(TO_LAB_Subs->Subs[i].Stream))
@@ -395,7 +396,8 @@ int32 TO_LAB_SendDataTypes(const TO_LAB_SendDataTypesCmd_t *data)
     char  string_variable[10] = "ABCDEFGHIJ";
 
     /* initialize data types packet */
-    CFE_MSG_Init(&TO_LAB_Global.DataTypesTlm.TlmHeader.Msg, TO_LAB_DATA_TYPES_MID, sizeof(TO_LAB_Global.DataTypesTlm));
+    CFE_MSG_Init(&TO_LAB_Global.DataTypesTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(TO_LAB_DATA_TYPES_MID),
+                 sizeof(TO_LAB_Global.DataTypesTlm));
 
     CFE_SB_TimeStampMsg(&TO_LAB_Global.DataTypesTlm.TlmHeader.Msg);
 


### PR DESCRIPTION
**Describe the contribution**
Whenever an integer value is used as a CFE_SB_MsgId_t, it should go through the explicit conversion using the supplied inline function.

This also corrects another type mismatch/inconsistency regarding TO_UNUSED check.

Fixes #103

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
Allows TO_LAB to be built when CFE_SB_MsgId_t is an opaque/non-integer type.
None with default config (where CFE_SB_MsgId_t is an integer type).

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.