### PR TITLE
Fix #123, update cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.5)
 project(CFS_TO_LAB C)
 
 # Include source directory for table use


### PR DESCRIPTION
**Describe the contribution**
Fixes the warning that support for old versions will be removed
The build does not actually expect such an old version

Fixes #123

**Testing performed**
Build using cmake 3.20

**Expected behavior changes**
No deprecation warning

**System(s) tested on**
RHEL 8

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
