### PR TITLE
Fix #73, Remove unused PktSize variable.

### DIFF
--- a/fsw/src/to_lab_msg.h
+++ b/fsw/src/to_lab_msg.h
@@ -98,7 +98,6 @@ typedef TO_LAB_NoArgsCmd_t TO_LAB_SendDataTypesCmd_t;
 typedef struct
 {
     CFE_SB_MsgId_t Stream;
-    uint16         PktSize;
     CFE_SB_Qos_t   Flags;
     uint8          BufLimit;
 } TO_LAB_AddPacket_Payload_t;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #73
Removes the unused PktSize variable from the TO_LAB_AddPacket_Payload_t struct.

**Testing performed**
None, prior to submission.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 