### PR TITLE
Fix #133, Apply consistent Event ID names to common events

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -188,7 +188,7 @@ int32 TO_LAB_init(void)
         CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_SEND_HK_MID), TO_LAB_Global.Cmd_pipe);
     }
     else
-        CFE_EVS_SendEvent(TO_LAB_CRCMDPIPE_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't create cmd pipe status %i",
+        CFE_EVS_SendEvent(TO_LAB_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't create cmd pipe status %i",
                           __LINE__, (int)status);
 
     /* Create TO TLM pipe */
@@ -285,7 +285,7 @@ void TO_LAB_process_commands(void)
                         break;
 
                     default:
-                        CFE_EVS_SendEvent(TO_LAB_MSGID_ERR_EID, CFE_EVS_EventType_ERROR,
+                        CFE_EVS_SendEvent(TO_LAB_MID_ERR_EID, CFE_EVS_EventType_ERROR,
                                           "L%d TO: Invalid Msg ID Rcvd 0x%x", __LINE__,
                                           (unsigned int)CFE_SB_MsgIdToValue(MsgId));
                         break;

--- a/fsw/src/to_lab_events.h
+++ b/fsw/src/to_lab_events.h
@@ -29,13 +29,13 @@
 #define TO_LAB_EVM_RESERVED 0
 
 #define TO_LAB_INIT_INF_EID          1
-#define TO_LAB_CRCMDPIPE_ERR_EID     2
+#define TO_LAB_CR_PIPE_ERR_EID       2
 #define TO_LAB_TLMOUTENA_INF_EID     3
 #define TO_LAB_SUBSCRIBE_ERR_EID     4
 #define TO_LAB_TLMPIPE_ERR_EID       5
 #define TO_LAB_TLMOUTSOCKET_ERR_EID  6
 #define TO_LAB_TLMOUTSTOP_ERR_EID    7
-#define TO_LAB_MSGID_ERR_EID         8
+#define TO_LAB_MID_ERR_EID           8
 #define TO_LAB_FNCODE_ERR_EID        9
 #define TO_LAB_ADDPKT_ERR_EID        10
 #define TO_LAB_REMOVEPKT_ERR_EID     11


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #133 
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt