### PR TITLE
Fix #135, Add version information to NOOP event

### DIFF
--- a/fsw/src/to_lab_cmds.c
+++ b/fsw/src/to_lab_cmds.c
@@ -22,12 +22,14 @@
  */
 
 #include "cfe.h"
+#include "cfe_config.h" // For CFE_Config_GetVersionString
 
 #include "to_lab_app.h"
 #include "to_lab_cmds.h"
 #include "to_lab_msg.h"
 #include "to_lab_eventids.h"
 #include "to_lab_msgids.h"
+#include "to_lab_version.h"
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -61,9 +63,15 @@ CFE_Status_t TO_LAB_EnableOutputCmd(const TO_LAB_EnableOutputCmd_t *data)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 CFE_Status_t TO_LAB_NoopCmd(const TO_LAB_NoopCmd_t *data)
 {
-    CFE_EVS_SendEvent(TO_LAB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command");
-    ++TO_LAB_Global.HkTlm.Payload.CommandCounter;
-    return CFE_SUCCESS;
+  char VersionString[TO_LAB_CFG_MAX_VERSION_STR_LEN];
+
+  CFE_Config_GetVersionString(VersionString, TO_LAB_CFG_MAX_VERSION_STR_LEN, "TO Lab",
+                        TO_LAB_VERSION, TO_LAB_BUILD_CODENAME, TO_LAB_LAST_OFFICIAL);
+
+  CFE_EVS_SendEvent(TO_LAB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "TO: NOOP command. %s", VersionString);
+
+  ++TO_LAB_Global.HkTlm.Payload.CommandCounter;
+  return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #135 
  - Version information added in to NOOP event.

**Testing performed**
Run/Build and confirmed NOOP command event reporting as expected.
![Screenshot 2022-10-22 21 00 58](https://user-images.githubusercontent.com/9024662/197336144-9bcf6440-8486-4740-8d7d-2d525d2ea21f.png)

**Expected behavior changes**
Adds version information to NOOP command to align with the other cFS components/apps.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)

**Contributor Info**
Avi Weiss @thnkslprpt