### PR TITLE
Fix #137, Reduce length of string_variable[] initializer string

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -157,8 +157,8 @@ int32 TO_LAB_init(void)
 
     if (status != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(TO_LAB_TBL_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't register table status %i", __LINE__,
-                          (int)status);
+        CFE_EVS_SendEvent(TO_LAB_TBL_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't register table status %i",
+                          __LINE__, (int)status);
         return status;
     }
 
@@ -175,8 +175,8 @@ int32 TO_LAB_init(void)
 
     if (status != CFE_SUCCESS && status != CFE_TBL_INFO_UPDATED)
     {
-        CFE_EVS_SendEvent(TO_LAB_TBL_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't get table addr status %i", __LINE__,
-                          (int)status);
+        CFE_EVS_SendEvent(TO_LAB_TBL_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't get table addr status %i",
+                          __LINE__, (int)status);
         return status;
     }
 
@@ -224,8 +224,8 @@ int32 TO_LAB_init(void)
     */
     OS_TaskInstallDeleteHandler(&TO_LAB_delete_callback);
 
-    CFE_EVS_SendEvent(TO_LAB_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "TO Lab Initialized.%s, Awaiting enable command.",
-                      TO_LAB_VERSION_STRING);
+    CFE_EVS_SendEvent(TO_LAB_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
+                      "TO Lab Initialized.%s, Awaiting enable command.", TO_LAB_VERSION_STRING);
 
     return CFE_SUCCESS;
 }
@@ -285,8 +285,9 @@ void TO_LAB_process_commands(void)
                         break;
 
                     default:
-                        CFE_EVS_SendEvent(TO_LAB_MSGID_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO: Invalid Msg ID Rcvd 0x%x",
-                                          __LINE__, (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+                        CFE_EVS_SendEvent(TO_LAB_MSGID_ERR_EID, CFE_EVS_EventType_ERROR,
+                                          "L%d TO: Invalid Msg ID Rcvd 0x%x", __LINE__,
+                                          (unsigned int)CFE_SB_MsgIdToValue(MsgId));
                         break;
                 }
                 break;
@@ -378,7 +379,7 @@ int32 TO_LAB_ResetCounters(const TO_LAB_ResetCountersCmd_t *data)
 int32 TO_LAB_SendDataTypes(const TO_LAB_SendDataTypesCmd_t *data)
 {
     int16 i;
-    char  string_variable[10] = "ABCDEFGHIJ";
+    char  string_variable[10] = "ABCDEFGHI";
 
     /* initialize data types packet */
     CFE_MSG_Init(CFE_MSG_PTR(TO_LAB_Global.DataTypesTlm.TelemetryHeader), CFE_SB_ValueToMsgId(TO_LAB_DATA_TYPES_MID),
@@ -445,8 +446,8 @@ void TO_LAB_openTLM(void)
     status = OS_SocketOpen(&TO_LAB_Global.TLMsockid, OS_SocketDomain_INET, OS_SocketType_DATAGRAM);
     if (status != OS_SUCCESS)
     {
-        CFE_EVS_SendEvent(TO_LAB_TLMOUTSOCKET_ERR_EID, CFE_EVS_EventType_ERROR, "L%d, TO TLM socket error: %d", __LINE__,
-                          (int)status);
+        CFE_EVS_SendEvent(TO_LAB_TLMOUTSOCKET_ERR_EID, CFE_EVS_EventType_ERROR, "L%d, TO TLM socket error: %d",
+                          __LINE__, (int)status);
     }
 
     /*---------------- Add static arp entries ----------------*/
@@ -465,11 +466,12 @@ int32 TO_LAB_AddPacket(const TO_LAB_AddPacketCmd_t *data)
     status = CFE_SB_SubscribeEx(pCmd->Stream, TO_LAB_Global.Tlm_pipe, pCmd->Flags, pCmd->BufLimit);
 
     if (status != CFE_SUCCESS)
-        CFE_EVS_SendEvent(TO_LAB_ADDPKT_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't subscribe 0x%x status %i", __LINE__,
-                          (unsigned int)CFE_SB_MsgIdToValue(pCmd->Stream), (int)status);
+        CFE_EVS_SendEvent(TO_LAB_ADDPKT_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO Can't subscribe 0x%x status %i",
+                          __LINE__, (unsigned int)CFE_SB_MsgIdToValue(pCmd->Stream), (int)status);
     else
-        CFE_EVS_SendEvent(TO_LAB_ADDPKT_INF_EID, CFE_EVS_EventType_INFORMATION, "L%d TO AddPkt 0x%x, QoS %d.%d, limit %d",
-                          __LINE__, (unsigned int)CFE_SB_MsgIdToValue(pCmd->Stream), pCmd->Flags.Priority,
+        CFE_EVS_SendEvent(TO_LAB_ADDPKT_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "L%d TO AddPkt 0x%x, QoS %d.%d, limit %d", __LINE__,
+                          (unsigned int)CFE_SB_MsgIdToValue(pCmd->Stream), pCmd->Flags.Priority,
                           pCmd->Flags.Reliability, pCmd->BufLimit);
 
     ++TO_LAB_Global.HkTlm.Payload.CommandCounter;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #137
Reduced the length of the initializer-string for `string_variable[]` so as to avoid potential overflow due to automatic addition of the terminating null character by the compiler.

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No impact on code behavior.

**Contributor Info**
Avi Weiss @thnkslprpt