### PR TITLE
Fix #147, Add check for failure of `CFE_EVS_Register()` during initialization

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -146,7 +146,13 @@ int32 TO_LAB_init(void)
     /*
     ** Register with EVS
     */
-    CFE_EVS_Register(NULL, 0, CFE_EVS_EventFilter_BINARY);
+    status = CFE_EVS_Register(NULL, 0, CFE_EVS_EventFilter_BINARY);
+    if (status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TO_LAB: Error registering for Event Services, RC = 0x%08X\n", (unsigned int)status);
+        return status;
+    }
+
     /*
     ** Initialize housekeeping packet (clear user data area)...
     */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #147
  - Adds checks for failure during call to `CFE_EVS_Register()` in the initialization sequence.

Recommend refactoring `TO_LAB_init()` in future to avoid the need for these early returns.

**Testing performed**
GitHub CI actions all passing successfully.
Local tests confirm builds and run fine, and cFS tests all passing.

**Expected behavior changes**
Use will be informed of failure of `CFE_EVS_Register()` rather than it failing silently.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt