### PR TITLE
Fix #152, adjust subscription table based on apps present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,20 @@
 cmake_minimum_required(VERSION 3.5)
 project(CFS_TO_LAB C)
 
+set(TO_TABLE_COMPILE_DEFS)
+
 # These references are specifically needed for the table build
 # it is easiest to add them as directory properties so they won't
-# be considered include directories for TO_LAB itself.
-include_directories(
-    $<TARGET_PROPERTY:ci_lab,INTERFACE_INCLUDE_DIRECTORIES>
-    $<TARGET_PROPERTY:sample_app,INTERFACE_INCLUDE_DIRECTORIES>
-)
+# be considered include directories for TO_LAB itself.  Each one
+# gets a macro for conditional inclusion in the subscription table.
+foreach(EXT_APP ci_lab sample_app hs fm ds sc lc)
+  list (FIND TGTSYS_${SYSVAR}_APPS ${EXT_APP} HAVE_APP)
+  if (HAVE_APP GREATER_EQUAL 0)
+    include_directories($<TARGET_PROPERTY:${EXT_APP},INTERFACE_INCLUDE_DIRECTORIES>)
+    string(TOUPPER "HAVE_${EXT_APP}" APP_MACRO)
+    add_definitions(-D${APP_MACRO})
+  endif()
+endforeach()
 
 set(APP_SRC_FILES
     fsw/src/to_lab_app.c

--- a/fsw/tables/to_lab_sub.c
+++ b/fsw/tables/to_lab_sub.c
@@ -28,37 +28,39 @@
 /*
 ** Add the proper include file for the message IDs below
 */
-
-/*
-** Common CFS app includes below are commented out
-*/
 #include "to_lab_msgids.h"
+
+#ifdef HAVE_CI_LAB
 #include "ci_lab_msgids.h"
+#endif
 
+#ifdef HAVE_SAMPLE_APP
 #include "sample_app_msgids.h"
+#endif
 
-#if 0
+#ifdef HAVE_HS_APP
 #include "hs_msgids.h"
+#endif
+
+#ifdef HAVE_FM_APP
 #include "fm_msgids.h"
+#endif
+
+#ifdef HAVE_SC_APP
 #include "sc_msgids.h"
+#endif
+
+#ifdef HAVE_DS_APP
 #include "ds_msgids.h"
+#endif
+
+#ifdef HAVE_LC_APP
 #include "lc_msgids.h"
 #endif
 
 TO_LAB_Subs_t TO_LAB_Subs = {.Subs = {/* CFS App Subscriptions */
                                       {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_HK_TLM_MID), {0, 0}, 4},
                                       {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_DATA_TYPES_MID), {0, 0}, 4},
-                                      {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_HK_TLM_MID), {0, 0}, 4},
-                                      {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_HK_TLM_MID), {0, 0}, 4},
-
-#if 0
-        /* Add these if needed */
-        {CFE_SB_MSGID_WRAP_VALUE(HS_HK_TLM_MID), {0,0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(FM_HK_TLM_MID), {0,0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(SC_HK_TLM_MID), {0,0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(DS_HK_TLM_MID), {0,0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(LC_HK_TLM_MID), {0,0}, 4},
-#endif
 
                                       /* cFE Core subscriptions */
                                       {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_HK_TLM_MID), {0, 0}, 4},
@@ -73,6 +75,28 @@ TO_LAB_Subs_t TO_LAB_Subs = {.Subs = {/* CFS App Subscriptions */
 
                                       {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_APP_TLM_MID), {0, 0}, 4},
                                       {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_MEMSTATS_TLM_MID), {0, 0}, 4},
+
+#ifdef HAVE_CI_LAB
+                                      {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_HK_TLM_MID), {0, 0}, 4},
+#endif
+#ifdef HAVE_SAMPLE_APP
+                                      {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_HK_TLM_MID), {0, 0}, 4},
+#endif
+#ifdef HAVE_HS_APP
+                                      {CFE_SB_MSGID_WRAP_VALUE(HS_HK_TLM_MID), {0, 0}, 4},
+#endif
+#ifdef HAVE_HS_APP
+                                      {CFE_SB_MSGID_WRAP_VALUE(FM_HK_TLM_MID), {0, 0}, 4},
+#endif
+#ifdef HAVE_HS_APP
+                                      {CFE_SB_MSGID_WRAP_VALUE(SC_HK_TLM_MID), {0, 0}, 4},
+#endif
+#ifdef HAVE_HS_APP
+                                      {CFE_SB_MSGID_WRAP_VALUE(DS_HK_TLM_MID), {0, 0}, 4},
+#endif
+#ifdef HAVE_HS_APP
+                                      {CFE_SB_MSGID_WRAP_VALUE(LC_HK_TLM_MID), {0, 0}, 4},
+#endif
 
                                       /* CFE_SB_MSGID_RESERVED entry to mark the end of valid MsgIds */
                                       {CFE_SB_MSGID_RESERVED, {0, 0}, 0}}};


### PR DESCRIPTION
**Describe the contribution**
Create an inclusion preprocessor macro for each app referred to in the subscription table, and only include that line if the app is present in the current configuration.

In particular, do not assume that sample_app will always be there.

Fixes #152

**Testing performed**
Build TO_LAB without SAMPLE_APP and confirm successful

**Expected behavior changes**
Presence of other apps is not assumed/hardcoded in the subscription table

**System(s) tested on**
Debian

**Additional context**
This should fix workflow errors where apps are built with TO_LAB but without SAMPLE_APP.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
