### PR TITLE
Fix #157, Move function prototypes to header file

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -30,46 +30,12 @@
 #include "to_lab_sub_table.h"
 
 /*
-** Global Data Section
+** TO Global Data Section
 */
-typedef struct
-{
-    CFE_SB_PipeId_t Tlm_pipe;
-    CFE_SB_PipeId_t Cmd_pipe;
-    osal_id_t       TLMsockid;
-    bool            downlink_on;
-    char            tlm_dest_IP[17];
-    bool            suppress_sendto;
-
-    TO_LAB_HkTlm_t        HkTlm;
-    TO_LAB_DataTypesTlm_t DataTypesTlm;
-} TO_LAB_GlobalData_t;
 
 TO_LAB_GlobalData_t TO_LAB_Global;
-
-TO_LAB_Subs_t *  TO_LAB_Subs;
-CFE_TBL_Handle_t TO_SubTblHandle;
-
-/*
-** Prototypes Section
-*/
-void  TO_LAB_openTLM(void);
-int32 TO_LAB_init(void);
-void  TO_LAB_exec_local_command(CFE_SB_Buffer_t *SBBufPtr);
-void  TO_LAB_process_commands(void);
-void  TO_LAB_forward_telemetry(void);
-
-/*
- * Individual Command Handler prototypes
- */
-int32 TO_LAB_AddPacket(const TO_LAB_AddPacketCmd_t *data);
-int32 TO_LAB_Noop(const TO_LAB_NoopCmd_t *data);
-int32 TO_LAB_EnableOutput(const TO_LAB_EnableOutputCmd_t *data);
-int32 TO_LAB_RemoveAll(const TO_LAB_RemoveAllCmd_t *data);
-int32 TO_LAB_RemovePacket(const TO_LAB_RemovePacketCmd_t *data);
-int32 TO_LAB_ResetCounters(const TO_LAB_ResetCountersCmd_t *data);
-int32 TO_LAB_SendDataTypes(const TO_LAB_SendDataTypesCmd_t *data);
-int32 TO_LAB_SendHousekeeping(const CFE_MSG_CommandHeader_t *data);
+TO_LAB_Subs_t *     TO_LAB_Subs;
+CFE_TBL_Handle_t    TO_SubTblHandle;
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                   */
@@ -344,6 +310,7 @@ void TO_LAB_exec_local_command(CFE_SB_Buffer_t *SBBufPtr)
                               "L%d TO: Invalid Function Code Rcvd In Ground Command 0x%x", __LINE__,
                               (unsigned int)CommandCode);
             ++TO_LAB_Global.HkTlm.Payload.CommandErrorCounter;
+            break;
     }
 }
 

--- a/fsw/src/to_lab_app.h
+++ b/fsw/src/to_lab_app.h
@@ -33,7 +33,11 @@
 #include "common_types.h"
 #include "osapi.h"
 
-/*****************************************************************************/
+#include "to_lab_msg.h"
+
+/************************************************************************
+ * Macro Definitions
+ ************************************************************************/
 
 #define TO_LAB_TASK_MSEC 500 /* run at 2 Hz */
 #define TO_LAB_UNUSED    CFE_SB_MSGID_RESERVED
@@ -52,13 +56,47 @@
 #define cfgTLM_PORT        1235
 #define TO_LAB_VERSION_NUM "5.1.0"
 
-/******************************************************************************/
+/************************************************************************
+** Type Definitions
+*************************************************************************/
+
+/**
+ * CI global data structure
+ */
+typedef struct
+{
+    CFE_SB_PipeId_t Tlm_pipe;
+    CFE_SB_PipeId_t Cmd_pipe;
+    osal_id_t       TLMsockid;
+    bool            downlink_on;
+    char            tlm_dest_IP[17];
+    bool            suppress_sendto;
+
+    TO_LAB_HkTlm_t        HkTlm;
+    TO_LAB_DataTypesTlm_t DataTypesTlm;
+} TO_LAB_GlobalData_t;
+
+/************************************************************************
+ * Function Prototypes
+ ************************************************************************/
+
+void  TO_LAB_AppMain(void);
+void  TO_LAB_openTLM(void);
+int32 TO_LAB_init(void);
+void  TO_LAB_exec_local_command(CFE_SB_Buffer_t *SBBufPtr);
+void  TO_LAB_process_commands(void);
+void  TO_LAB_forward_telemetry(void);
 
 /*
-** Prototypes Section
-*/
-void TO_LAB_AppMain(void);
-
-/******************************************************************************/
+ * Individual Command Handler prototypes
+ */
+int32 TO_LAB_AddPacket(const TO_LAB_AddPacketCmd_t *data);
+int32 TO_LAB_Noop(const TO_LAB_NoopCmd_t *data);
+int32 TO_LAB_EnableOutput(const TO_LAB_EnableOutputCmd_t *data);
+int32 TO_LAB_RemoveAll(const TO_LAB_RemoveAllCmd_t *data);
+int32 TO_LAB_RemovePacket(const TO_LAB_RemovePacketCmd_t *data);
+int32 TO_LAB_ResetCounters(const TO_LAB_ResetCountersCmd_t *data);
+int32 TO_LAB_SendDataTypes(const TO_LAB_SendDataTypesCmd_t *data);
+int32 TO_LAB_SendHousekeeping(const CFE_MSG_CommandHeader_t *data);
 
 #endif


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #157
  - Moves the function prototypes that were in `to_lab_app.c` over to the header file

**Testing performed**
GitHub CI actions all passing successfully.
Local testing with full cFS suite confirms app performance unaffected.

**Expected behavior changes**
No change to behavior.
Makes the file content more consistent with the rest of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt