### PR TITLE
Fix #162, Update misnamed `CmdHeader` variable in `to_lab_msg.h`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/fsw/src/to_lab_msg.h
+++ b/fsw/src/to_lab_msg.h
@@ -80,7 +80,7 @@ typedef struct
 
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeade; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } TO_LAB_NoArgsCmd_t;
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #162
  - Renamed the `CFE_MSG_CommandHeader_t` variable in `TO_LAB_NoArgsCmd_t` to ~~`CmdHeader`~~ `CommandHeader`


**Testing performed**
Tested locally by sending a few commands - all working fine.

**Expected behavior changes**
No change. Avoids potential confusion during future maintenance.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt