### PR TITLE
Fix #131, Rename `CommandCode` variable to `Fcncode`

### DIFF
--- a/fsw/src/to_lab_dispatch.c
+++ b/fsw/src/to_lab_dispatch.c
@@ -37,11 +37,11 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void TO_LAB_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
 {
-    CFE_MSG_FcnCode_t CommandCode = 0;
+    CFE_MSG_FcnCode_t FcnCode = 0;
 
-    CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &CommandCode);
+    CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &FcnCode);
 
-    switch (CommandCode)
+    switch (FcnCode)
     {
         case TO_LAB_NOOP_CC:
             TO_LAB_NoopCmd((const TO_LAB_NoopCmd_t *)SBBufPtr);
@@ -74,7 +74,7 @@ void TO_LAB_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
         default:
             CFE_EVS_SendEvent(TO_LAB_FNCODE_ERR_EID, CFE_EVS_EventType_ERROR,
                               "L%d TO: Invalid Function Code Rcvd In Ground Command 0x%x", __LINE__,
-                              (unsigned int)CommandCode);
+                              (unsigned int)FcnCode);
             ++TO_LAB_Global.HkTlm.Payload.CommandErrorCounter;
     }
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #131
  - Rename the `CommandCode` variable in `TO_LAB_exec_local_command()` to `FcnCode` to better align with the cFE API.
  - this PR replaces https://github.com/nasa/to_lab/pull/132 which was closed by mistake (I still can't figure out how to deal with rebases that remove all changes, and then add back the actual changes from PR into 1 commit without closing the issue...)

**Testing performed**
Standard cFS bundle tests all passed.
Build/run cFS and test NOOP and other commands with the GroundSystem tool. All working fine.

**Expected behavior changes**
No impact on behavior.
Improves code clarity and consistency in the lab apps.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
cFS main branch

**Contributor Info**
Avi Weiss @thnkslprpt