### PR TITLE
Fix #175, define msgids via topicids

### DIFF
--- a/arch_build.cmake
+++ b/arch_build.cmake
@@ -20,8 +20,14 @@ set(TO_LAB_PLATFORM_CONFIG_FILE_LIST
 # This makes them individually overridable by the missions, without modifying
 # the distribution default copies
 foreach(TO_LAB_CFGFILE ${TO_LAB_PLATFORM_CONFIG_FILE_LIST})
+  get_filename_component(CFGKEY "${TO_LAB_CFGFILE}" NAME_WE)
+  if (DEFINED TO_LAB_CFGFILE_SRC_${CFGKEY})
+    set(DEFAULT_SOURCE GENERATED_FILE "${TO_LAB_CFGFILE_SRC_${CFGKEY}}")
+  else()
+    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${TO_LAB_CFGFILE}")
+  endif()
   generate_config_includefile(
     FILE_NAME           "${TO_LAB_CFGFILE}"
-    FALLBACK_FILE       "${CMAKE_CURRENT_LIST_DIR}/config/default_${TO_LAB_CFGFILE}"
+    ${DEFAULT_SOURCE}
   )
 endforeach()

--- a/config/default_to_lab_topicids.h
+++ b/config/default_to_lab_topicids.h
@@ -18,17 +18,14 @@
 
 /**
  * @file
- *   TO_LAB Application Message IDs
+ *   TO_LAB Application Topic IDs
  */
-#ifndef TO_LAB_MSGIDS_H
-#define TO_LAB_MSGIDS_H
+#ifndef TO_LAB_TOPICIDS_H
+#define TO_LAB_TOPICIDS_H
 
-#include "cfe_core_api_base_msgids.h"
-#include "to_lab_topicids.h"
-
-#define TO_LAB_CMD_MID        CFE_PLATFORM_CMD_TOPICID_TO_MIDV(TO_LAB_CMD_TOPICID)
-#define TO_LAB_SEND_HK_MID    CFE_PLATFORM_CMD_TOPICID_TO_MIDV(TO_LAB_SEND_HK_TOPICID)
-#define TO_LAB_HK_TLM_MID     CFE_PLATFORM_TLM_TOPICID_TO_MIDV(TO_LAB_HK_TLM_TOPICID)
-#define TO_LAB_DATA_TYPES_MID CFE_PLATFORM_TLM_TOPICID_TO_MIDV(TO_LAB_DATA_TYPES_TOPICID)
+#define TO_LAB_CMD_TOPICID        0x80
+#define TO_LAB_SEND_HK_TOPICID    0x81
+#define TO_LAB_HK_TLM_TOPICID     0x80
+#define TO_LAB_DATA_TYPES_TOPICID 0x81
 
 #endif

--- a/mission_build.cmake
+++ b/mission_build.cmake
@@ -20,6 +20,7 @@ set(TO_LAB_MISSION_CONFIG_FILE_LIST
   to_lab_tbl.h
   to_lab_tbldefs.h
   to_lab_tblstruct.h
+  to_lab_topicids.h
 )
 
 if (CFE_EDS_ENABLED_BUILD)


### PR DESCRIPTION
**Describe the contribution**
The MsgID value is a conversion from TopicID

Fixes #175

**Testing performed**
Build and run tests

**Expected behavior changes**
None, topic IDs were chosen such that the resulting MsgIDs are the same when using default config

**System(s) tested on**
Debian

**Additional context**
Depends on nasa/cfe#2474

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
