### PR TITLE
Fix #177, update macros for to table

### DIFF
--- a/fsw/tables/to_lab_sub.c
+++ b/fsw/tables/to_lab_sub.c
@@ -39,23 +39,23 @@
 #include "sample_app_msgids.h"
 #endif
 
-#ifdef HAVE_HS_APP
+#ifdef HAVE_HS
 #include "hs_msgids.h"
 #endif
 
-#ifdef HAVE_FM_APP
+#ifdef HAVE_FM
 #include "fm_msgids.h"
 #endif
 
-#ifdef HAVE_SC_APP
+#ifdef HAVE_SC
 #include "sc_msgids.h"
 #endif
 
-#ifdef HAVE_DS_APP
+#ifdef HAVE_DS
 #include "ds_msgids.h"
 #endif
 
-#ifdef HAVE_LC_APP
+#ifdef HAVE_LC
 #include "lc_msgids.h"
 #endif
 
@@ -83,19 +83,19 @@ TO_LAB_Subs_t TO_LAB_Subs = {.Subs = {/* CFS App Subscriptions */
 #ifdef HAVE_SAMPLE_APP
                                       {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_HK_TLM_MID), {0, 0}, 4},
 #endif
-#ifdef HAVE_HS_APP
+#ifdef HAVE_HS
                                       {CFE_SB_MSGID_WRAP_VALUE(HS_HK_TLM_MID), {0, 0}, 4},
 #endif
-#ifdef HAVE_HS_APP
+#ifdef HAVE_FM
                                       {CFE_SB_MSGID_WRAP_VALUE(FM_HK_TLM_MID), {0, 0}, 4},
 #endif
-#ifdef HAVE_HS_APP
+#ifdef HAVE_SC
                                       {CFE_SB_MSGID_WRAP_VALUE(SC_HK_TLM_MID), {0, 0}, 4},
 #endif
-#ifdef HAVE_HS_APP
+#ifdef HAVE_DS
                                       {CFE_SB_MSGID_WRAP_VALUE(DS_HK_TLM_MID), {0, 0}, 4},
 #endif
-#ifdef HAVE_HS_APP
+#ifdef HAVE_LC
                                       {CFE_SB_MSGID_WRAP_VALUE(LC_HK_TLM_MID), {0, 0}, 4},
 #endif
 


### PR DESCRIPTION
Fix #177 update the macros for to table

**Describe the contribution**
Fix #177. Update Macros for to table. 

**Testing performed**
Steps taken to test the contribution:
1. Add in HS, SC, FM, DS, LC app 
2. make SIMULATION=native prep
3. make install
4. Verify HK package from CI_Lab, sample_app, hs, sc, fm, ds, lc using COSMOS ground system. 

**Expected behavior changes**
You can receive HK telemetry for the following apps: CI, sample, hs, sc,fm, ds, lc 

**System(s) tested on**
 - ubuntu 22.04
 - Cosmos

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
- If NASA Civil Servant Employee or GSFC Contractor on SES II
  - Address/email/phone and contract/task information (if applicable) must be on file
- Else if Company
  - **HAND SIGNED** Company CLA must be on file (once per release): [Company CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Corp_CLA_form_1219.pdf)
- Else if Individual
  - **HAND SIGNED** Individual CLA must be on file (once per release): [Individual CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Ind_CLA_form_1219.pdf)

Anh Van, GSFC
