### PR TITLE
Fix #179, Light initialization logic refactor + remove multiple returns

### DIFF
--- a/fsw/src/to_lab_dispatch.c
+++ b/fsw/src/to_lab_dispatch.c
@@ -76,6 +76,7 @@ void TO_LAB_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
                               "L%d TO: Invalid Function Code Rcvd In Ground Command 0x%x", __LINE__,
                               (unsigned int)CommandCode);
             ++TO_LAB_Global.HkTlm.Payload.CommandErrorCounter;
+            break;
     }
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #179
  - `TO_LAB_init` refactored to remove multiple returns, and not continue with subsequent steps after a serious failure of a call to cFE during the initialization

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
Tested locally with cFS build + test commands - all working fine.


**Expected behavior changes**
- if `CFE_SB_CreatePipe` fails when creating the command pipe, to_lab will not go on try to create the telemetry pipe.
- if `CFE_SB_CreatePipe` fails when creating the telemetry pipe, to_lab will not try to add the subscriptions - which makes little sense anyway...
- also, in neither case will to_lab now report successful initialization if the pipes cannot be created.
- the delete handler will be installed now in all cases even if one of the early calls to cFE fails - this is the case also in other apps.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt