### PR TITLE
Fix #164, updating to_lab to use new versioning system.

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -22,6 +22,7 @@
  */
 
 #include "cfe.h"
+#include "cfe_config.h"
 
 #include "to_lab_app.h"
 #include "to_lab_encode.h"
@@ -104,6 +105,7 @@ CFE_Status_t TO_LAB_init(void)
     uint16        ToTlmPipeDepth;
     void *        TblPtr;
     TO_LAB_Sub_t *SubEntry;
+    char          VersionString[TO_LAB_CFG_MAX_VERSION_STR_LEN];
 
     TO_LAB_Global.downlink_on = false;
     PipeDepth                 = TO_LAB_CMD_PIPE_DEPTH;
@@ -202,8 +204,11 @@ CFE_Status_t TO_LAB_init(void)
     */
     OS_TaskInstallDeleteHandler(&TO_LAB_delete_callback);
 
+    CFE_Config_GetVersionString(VersionString, TO_LAB_CFG_MAX_VERSION_STR_LEN, "TO Lab",
+                          TO_LAB_VERSION, TO_LAB_BUILD_CODENAME, TO_LAB_LAST_OFFICIAL);
+
     CFE_EVS_SendEvent(TO_LAB_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
-                      "TO Lab Initialized.%s, Awaiting enable command.", TO_LAB_VERSION_STRING);
+                      "TO Lab Initialized.%s, Awaiting enable command.", VersionString);
 
     return CFE_SUCCESS;
 }

--- a/fsw/src/to_lab_version.h
+++ b/fsw/src/to_lab_version.h
@@ -24,16 +24,22 @@
 #define TO_LAB_VERSION_H
 
 /* Development Build Macro Definitions */
-#define TO_LAB_BUILD_NUMBER 75 /*!< Development Build: Number of commits since baseline */
-#define TO_LAB_BUILD_BASELINE \
-    "v2.5.0-rc4" /*!< Development Build: git tag that is the base for the current development */
+#define TO_LAB_BUILD_NUMBER     75 /*!< Development Build: Number of commits since baseline */
+#define TO_LAB_BUILD_BASELINE   "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
+#define TO_LAB_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define TO_LAB_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define TO_LAB_MAJOR_VERSION 2  /*!< @brief Major version number */
 #define TO_LAB_MINOR_VERSION 3  /*!< @brief Minor version number */
-#define TO_LAB_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define TO_LAB_REVISION      0 /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define TO_LAB_LAST_OFFICIAL "v2.3.0"
 
 /*!
  * @brief Mission revision.
@@ -53,12 +59,12 @@
  */
 #define TO_LAB_VERSION TO_LAB_BUILD_BASELINE "+dev" TO_LAB_STR(TO_LAB_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
- * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that a TO_LAB version string can be.
+ * 
  */
-#define TO_LAB_VERSION_STRING                   \
-    " TO Lab DEVELOPMENT BUILD " TO_LAB_VERSION \
-    ", Last Official Release: v2.3.0" /* For full support please use this version */
+#define TO_LAB_CFG_MAX_VERSION_STR_LEN 256
 
 #endif


### PR DESCRIPTION
**Describe the contribution**
Fixes #164.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "TO_LAB_BUILD_DEV_CYCLE" macro has been defined
4. Version String has been removed, and all references to it replaced with the Build Baseline/Codename

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC