### PR TITLE
Fix #187, Zero-out global data during init + set `RunStatus` to `APP_ERROR` if init fails

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -53,7 +53,10 @@ void TO_LAB_AppMain(void)
 
     if (status != CFE_SUCCESS)
     {
-        return;
+        /*
+        ** Set request to terminate main loop...
+        */
+        RunStatus = CFE_ES_RunStatus_APP_ERROR;
     }
 
     /*
@@ -104,6 +107,9 @@ CFE_Status_t TO_LAB_init(void)
     uint16        ToTlmPipeDepth;
     void *        TblPtr;
     TO_LAB_Sub_t *SubEntry;
+
+    /* Zero out the global data structure */
+    memset(&TO_LAB_Global, 0, sizeof(TO_LAB_Global));
 
     TO_LAB_Global.downlink_on = false;
     PipeDepth                 = TO_LAB_CMD_PIPE_DEPTH;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #187 
  - Sets `RunStatus` to `CFE_ES_RunStatus_APP_ERROR` if initialization fails rather than a simple `return`.
  - Also added a `memset` to zero-out the global data structure at the start of the initialization routine

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
Tested locally with cFS suite + Ground System tool to confirm start-up and commands still working as expected.

**Expected behavior changes**
`CFE_ES_ExitApp()` will now be called if initialization fails, rather than simply exiting out of the function with the `return` statement.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt