### PR TITLE
Fix #201, Add build-run-app workflow to CI

### DIFF
--- a/.github/workflows/build-run-app.yml
+++ b/.github/workflows/build-run-app.yml
@@ -1,0 +1,13 @@
+name: Build and Run
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-run:
+    name: Build and run with startup msg verification
+    uses: nasa/cFS/.github/workflows/build-run-app.yml@main
+    with:
+      startup-string: "TO Lab Initialized"
+      is_framework_app: true


### PR DESCRIPTION
0**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #201 
  - Adds `build-run-app.yml` workflow to to_lab

**Testing performed**
GitHub CI actions all passing successfully.  
Tested with the cFS bundle on a forked branch and confirmed working as expected - for success & failure.

**Expected behavior changes**
Immediate feedback now possible for changes that cause:
- an issue with the build
- general compatibility issues with cFS

**Additional context**
Depends on the cFS PR, so I'll re-run workflows here after that one is merged in, and then this can also be merged:
- https://github.com/nasa/cFS/pull/799

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt