### PR TITLE
Fix #209, add number of successful subscriptions to initialisation event message

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -223,7 +223,8 @@ CFE_Status_t TO_LAB_init(void)
                                     TO_LAB_BUILD_CODENAME, TO_LAB_LAST_OFFICIAL);
 
         CFE_EVS_SendEvent(TO_LAB_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
-                          "TO Lab Initialized.%s, Awaiting enable command.", VersionString);
+                          "TO Lab Initialized.%s, Subscribed to %d messages. Awaiting enable command.", VersionString,
+                          i);
     }
 
     /*

--- a/fsw/src/to_lab_app.h
+++ b/fsw/src/to_lab_app.h
@@ -54,7 +54,7 @@ typedef struct
     TO_LAB_HkTlm_t        HkTlm;
     TO_LAB_DataTypesTlm_t DataTypesTlm;
 
-    TO_LAB_Subs_t *  SubsTblPtr;
+    TO_LAB_Subs_t   *SubsTblPtr;
     CFE_TBL_Handle_t SubsTblHandle;
 
 } TO_LAB_GlobalData_t;
@@ -63,11 +63,11 @@ typedef struct
  * Function Prototypes
  ************************************************************************/
 
-void  TO_LAB_AppMain(void);
-void  TO_LAB_openTLM(void);
-int32 TO_LAB_init(void);
-void  TO_LAB_process_commands(void);
-void  TO_LAB_forward_telemetry(void);
+void         TO_LAB_AppMain(void);
+void         TO_LAB_openTLM(void);
+CFE_Status_t TO_LAB_init(void);
+void         TO_LAB_process_commands(void);
+void         TO_LAB_forward_telemetry(void);
 
 /******************************************************************************/
 

--- a/fsw/src/to_lab_cmds.c
+++ b/fsw/src/to_lab_cmds.c
@@ -63,15 +63,15 @@ CFE_Status_t TO_LAB_EnableOutputCmd(const TO_LAB_EnableOutputCmd_t *data)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 CFE_Status_t TO_LAB_NoopCmd(const TO_LAB_NoopCmd_t *data)
 {
-  char VersionString[TO_LAB_CFG_MAX_VERSION_STR_LEN];
+    char VersionString[TO_LAB_CFG_MAX_VERSION_STR_LEN];
 
-  CFE_Config_GetVersionString(VersionString, TO_LAB_CFG_MAX_VERSION_STR_LEN, "TO Lab",
-                        TO_LAB_VERSION, TO_LAB_BUILD_CODENAME, TO_LAB_LAST_OFFICIAL);
+    CFE_Config_GetVersionString(VersionString, TO_LAB_CFG_MAX_VERSION_STR_LEN, "TO Lab", TO_LAB_VERSION,
+                                TO_LAB_BUILD_CODENAME, TO_LAB_LAST_OFFICIAL);
 
-  CFE_EVS_SendEvent(TO_LAB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "TO: NOOP command. %s", VersionString);
+    CFE_EVS_SendEvent(TO_LAB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "TO: NOOP command. %s", VersionString);
 
-  ++TO_LAB_Global.HkTlm.Payload.CommandCounter;
-  return CFE_SUCCESS;
+    ++TO_LAB_Global.HkTlm.Payload.CommandCounter;
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/to_lab_dispatch.c
+++ b/fsw/src/to_lab_dispatch.c
@@ -98,8 +98,8 @@ void TO_LAB_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
             break;
 
         default:
-            CFE_EVS_SendEvent(TO_LAB_MID_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO: Invalid Msg ID Rcvd 0x%x",
-                              __LINE__, (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+            CFE_EVS_SendEvent(TO_LAB_MID_ERR_EID, CFE_EVS_EventType_ERROR, "L%d TO: Invalid Msg ID Rcvd 0x%x", __LINE__,
+                              (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
     }
 }

--- a/fsw/src/to_lab_version.h
+++ b/fsw/src/to_lab_version.h
@@ -24,16 +24,17 @@
 #define TO_LAB_VERSION_H
 
 /* Development Build Macro Definitions */
-#define TO_LAB_BUILD_NUMBER     62 /*!< Development Build: Number of commits since baseline */
-#define TO_LAB_BUILD_BASELINE   "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
-#define TO_LAB_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
-#define TO_LAB_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
+#define TO_LAB_BUILD_NUMBER 62 /*!< Development Build: Number of commits since baseline */
+#define TO_LAB_BUILD_BASELINE \
+    "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
+#define TO_LAB_BUILD_DEV_CYCLE "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define TO_LAB_BUILD_CODENAME  "Equuleus"     /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
-#define TO_LAB_MAJOR_VERSION 2  /*!< @brief Major version number */
-#define TO_LAB_MINOR_VERSION 3  /*!< @brief Minor version number */
+#define TO_LAB_MAJOR_VERSION 2 /*!< @brief Major version number */
+#define TO_LAB_MINOR_VERSION 3 /*!< @brief Minor version number */
 #define TO_LAB_REVISION      0 /*!< @brief Revision version number. Value of 0 indicates a development version.*/
 
 /**
@@ -61,9 +62,9 @@
 
 /**
  * @brief Max Version String length.
- * 
+ *
  * Maximum length that a TO_LAB version string can be.
- * 
+ *
  */
 #define TO_LAB_CFG_MAX_VERSION_STR_LEN 256
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #209 
  - adds the number of successful TLM pipe subscriptions to the initialisation event message string - this would be useful in general, and especially in cases where zero subscriptions were successful despite this not being the expectation
  - minor correction to `TO_LAB_init` return type
  - rest is formatting updates applied according to the cFS bundle's `.clang-format` settings (no longer enforced in the CI)

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Additional useful information in initialisation message.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt