### PR TITLE
Fix #72 + Fix #206, Correct iteration bug in `TO_LAB_RemoveAllCmd`

### DIFF
--- a/fsw/src/to_lab_cmds.c
+++ b/fsw/src/to_lab_cmds.c
@@ -222,6 +222,8 @@ CFE_Status_t TO_LAB_RemoveAllCmd(const TO_LAB_RemoveAllCmd_t *data)
                                   "L%d TO Can't Unsubscribe to stream 0x%x status %i", __LINE__,
                                   (unsigned int)CFE_SB_MsgIdToValue(SubEntry->Stream), (int)status);
         }
+
+        SubEntry++;
     }
 
     CFE_EVS_SendEvent(TO_LAB_REMOVEALLPKTS_INF_EID, CFE_EVS_EventType_INFORMATION,


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #72  
- Fixes #206  
  - both issues actually had the same root cause which was the missing iteration of `SubEntry`, which caused the `TO_LAB_RemoveAllCmd` command try to to unsubscribe from the same entry `TO_LAB_MAX_SUBSCRIPTIONS` times

**Testing performed**
Tested with local cFS build to confirm prior and post-fix behavior is as described above.

**Expected behavior changes**
App will correctly iterate through the subs table now.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt