### PR TITLE
Fix nasa/cFS#952, Clamp encoded output size to CFE_MISSION_SB_MAX_SB_MSG_SIZE

### DIFF
--- a/fsw/src/to_lab_passthru_encode.c
+++ b/fsw/src/to_lab_passthru_encode.c
@@ -45,6 +45,11 @@ CFE_Status_t TO_LAB_EncodeOutputMessage(const CFE_SB_Buffer_t *SourceBuffer, con
 
     ResultStatus = CFE_MSG_GetSize(&SourceBuffer->Msg, &SourceBufferSize);
 
+    if (SourceBufferSize > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
+    {
+        SourceBufferSize = CFE_MISSION_SB_MAX_SB_MSG_SIZE;
+    }
+
     *DestBufferOut = SourceBuffer;
     *DestSizeOut   = SourceBufferSize;
 


### PR DESCRIPTION
**Describe the contribution**
- Fixes nasa/cFS#952
- `TO_LAB_EncodeOutputMessage` uses the CCSDS-derived size as the socket send length. A crafted Length field can cause `OS_SocketSendTo` to read past the SB buffer. Clamps the size to `CFE_MISSION_SB_MAX_SB_MSG_SIZE`, the upper bound of any SB allocation. This is the reporter's stated minimum remediation.

**Testing performed**
Compiled under the project's CMake flags with `-Werror` (no new warnings) and `clang-format --dry-run --Werror` against the repo `.clang-format` (clean). `apps/to_lab` has no UT scaffolding, so no test update was possible.

**Expected behavior changes**
Well-formed telemetry unaffected. A malformed message with an inflated Length field is now transmitted at the clamped size instead of reading adjacent heap memory. No API change.

**System(s) tested on**
- Local: macOS/AppleClang single-file compile
- Full Linux build/run/coverage runs in CI on this PR

**Additional context**
Partial remediation. Full elimination of the over-read requires SB-layer size tracking, which is the scope of nasa/cFS#953. The EDS variant `to_lab_eds_encode.c` has a related code path already bounded by `NetworkBuffer` and is left for a separate change to keep scope tight.

**Contributor Info**
Heath Dutton, Personal