### PR TITLE
Part cFS/workflows#136, Update CodeQL Logic

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   codeql:
     name: Codeql
-    uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
+    uses: nasa/cFS/.github/workflows/codeql-reusable.yml@dev
     with:
       component-path: apps/to_lab
       prep: 'make prep; make -C build/tools/elf2cfetbl'


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Part of an internal issue, cFS/workflows#136

**Testing performed**
[Tested cFS](https://github.com/arielswalker/cFS/actions/runs/25441035611)
[Tested OSAL (Default Build)](https://github.com/arielswalker/osal/actions/runs/25400685329)
[Tested OSAL (cFE Build)](https://github.com/arielswalker/osal/actions/runs/25400695616)
[Tested cFE](https://github.com/arielswalker/cFE/actions/runs/25401076476)
[Tested app (DS)](https://github.com/arielswalker/DS/actions/runs/25442205970)
[Tested ci_lab](https://github.com/nasa/ci_lab/actions/runs/25447314625)
[Tested sch_lab](https://github.com/nasa/sch_lab/actions/runs/25459127942)
[Tested SBN](https://github.com/nasa/SBN/actions/runs/25455781729?pr=82)

**Expected behavior changes**
CodeQL workflows now run successfully on the dev branches. 

**System(s) tested on**
GitHub Actions

**Additional context**
Uses helper action.yml files such as setup-app and setup-cfe along with updated build commands. Uses updated versions of actions. Uses same env variables as other workflows, `OMIT_DEPRECATED: false` and ` BUILDTYPE: debug`.

CodeQL workflows will not work in the PRs since they are calling the existing out-of-date dev branch version. Tests were done in a difference branch of my fork and provided in this PR. Relies on this [PR ](https://github.com/nasa/cFS/pull/994)to be merged.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.