### PR TITLE
Fix nasa#229, Check return values for CFE_SB_Subscribe in TO_LAB_init()

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -38,6 +38,11 @@
 */
 TO_LAB_GlobalData_t TO_LAB_Global;
 
+/*
+** TO Local Function Prototypes
+*/
+CFE_Status_t TO_LAB_CmdSubscribe(CFE_SB_MsgId_Atom_t MsgIdValue);
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                   */
 /* TO_LAB_AppMain() -- Application entry point and main process loop */
@@ -208,9 +213,16 @@ CFE_Status_t TO_LAB_init(void)
 
     if (status == CFE_SUCCESS)
     {
-        CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_CMD_MID), TO_LAB_Global.Cmd_pipe);
-        CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_SEND_HK_MID), TO_LAB_Global.Cmd_pipe);
+        status = TO_LAB_CmdSubscribe(TO_LAB_CMD_MID);
+    }
 
+    if (status == CFE_SUCCESS)
+    {
+        status = TO_LAB_CmdSubscribe(TO_LAB_SEND_HK_MID);
+    }
+
+    if (status == CFE_SUCCESS)
+    {
         /* Create TO TLM pipe */
         status = CFE_SB_CreatePipe(&TO_LAB_Global.Tlm_pipe, ToTlmPipeDepth, ToTlmPipeName);
         if (status != CFE_SUCCESS)
@@ -242,6 +254,29 @@ CFE_Status_t TO_LAB_init(void)
      ** Install the delete handler
      */
     OS_TaskInstallDeleteHandler(&TO_LAB_delete_callback);
+
+    return status;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* TO_LAB_CmdSubscribe() -- Subscribes to command message          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+CFE_Status_t TO_LAB_CmdSubscribe(CFE_SB_MsgId_Atom_t MsgIdValue)
+{
+    CFE_Status_t status;
+    status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(MsgIdValue), TO_LAB_Global.Cmd_pipe);
+
+    if (status != CFE_SUCCESS)
+    {
+        (void)CFE_EVS_SendEvent(TO_LAB_SUBSCRIBE_ERR_EID,
+                                CFE_EVS_EventType_ERROR,
+                                "L%d TO Can't subscribe to stream 0x%x status %i",
+                                __LINE__,
+                                (unsigned int)MsgIdValue,
+                                (int)status);
+    }
 
     return status;
 }


### PR DESCRIPTION
**Describe the contribution**
When subscribing to TO_LAB CMD and Send HK CMD, we are ignoring the return value.  This is captured in nasa#229.  

**Testing performed**
I did not run any unit tests because there were none written for TO_LAB using UT_assert.  

**Expected behavior changes**
 - Behavior Change: An error event message will be outputted if TO_LAB fails to subscribe to `TO_LAB_CMD_MID` or `TO_LAB_SEND_HK_MID`

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
