### PR TITLE
Fix nasa#231, to_lab app: strcpy() does not check bound.

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -124,9 +124,9 @@ CFE_Status_t TO_LAB_init(void)
     TO_LAB_Global.AllowPassthru = true;
     TO_LAB_Global.downlink_on   = false;
     PipeDepth                   = TO_LAB_PLATFORM_CMD_PIPE_DEPTH;
-    strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName)-1);
+    strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName) - 1);
     ToTlmPipeDepth = TO_LAB_PLATFORM_TLM_PIPE_DEPTH;
-    strncpy(ToTlmPipeName, "TO_LAB_TLM_PIPE", sizeof(ToTlmPipeName)-1);
+    strncpy(ToTlmPipeName, "TO_LAB_TLM_PIPE", sizeof(ToTlmPipeName) - 1);
 
     /*
     ** Register with EVS

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -124,9 +124,9 @@ CFE_Status_t TO_LAB_init(void)
     TO_LAB_Global.AllowPassthru = true;
     TO_LAB_Global.downlink_on   = false;
     PipeDepth                   = TO_LAB_PLATFORM_CMD_PIPE_DEPTH;
-    strcpy(PipeName, "TO_LAB_CMD_PIPE");
+    strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName)-1);
     ToTlmPipeDepth = TO_LAB_PLATFORM_TLM_PIPE_DEPTH;
-    strcpy(ToTlmPipeName, "TO_LAB_TLM_PIPE");
+    strncpy(ToTlmPipeName, "TO_LAB_TLM_PIPE", sizeof(ToTlmPipeName)-1);
 
     /*
     ** Register with EVS

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -126,7 +126,7 @@ CFE_Status_t TO_LAB_init(void)
     PipeDepth                   = TO_LAB_PLATFORM_CMD_PIPE_DEPTH;
     
     /* sizeof()-1 makes sure there's room for the null terminator when using strncpy */
-    strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName) -1);
+    strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName) - 1);
     /* Make sure a null terminator is added to the strncpy destination */
     PipeName[sizeof(PipeName) - 1] = '\0';
     ToTlmPipeDepth = TO_LAB_PLATFORM_TLM_PIPE_DEPTH;

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -124,12 +124,12 @@ CFE_Status_t TO_LAB_init(void)
     TO_LAB_Global.AllowPassthru = true;
     TO_LAB_Global.downlink_on   = false;
     PipeDepth                   = TO_LAB_PLATFORM_CMD_PIPE_DEPTH;
-    
+
     /* sizeof()-1 makes sure there's room for the null terminator when using strncpy */
     strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName) - 1);
     /* Make sure a null terminator is added to the strncpy destination */
     PipeName[sizeof(PipeName) - 1] = '\0';
-    ToTlmPipeDepth = TO_LAB_PLATFORM_TLM_PIPE_DEPTH;
+    ToTlmPipeDepth                 = TO_LAB_PLATFORM_TLM_PIPE_DEPTH;
     strncpy(ToTlmPipeName, "TO_LAB_TLM_PIPE", sizeof(ToTlmPipeName) - 1);
     ToTlmPipeName[sizeof(ToTlmPipeName) - 1] = '\0';
 

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -124,9 +124,14 @@ CFE_Status_t TO_LAB_init(void)
     TO_LAB_Global.AllowPassthru = true;
     TO_LAB_Global.downlink_on   = false;
     PipeDepth                   = TO_LAB_PLATFORM_CMD_PIPE_DEPTH;
-    strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName) - 1);
+    
+    /* sizeof()-1 makes sure there's room for the null terminator when using strncpy */
+    strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName) -1);
+    /* Make sure a null terminator is added to the strncpy destination */
+    PipeName[sizeof(PipeName) - 1] = '\0';
     ToTlmPipeDepth = TO_LAB_PLATFORM_TLM_PIPE_DEPTH;
     strncpy(ToTlmPipeName, "TO_LAB_TLM_PIPE", sizeof(ToTlmPipeName) - 1);
+    ToTlmPipeName[sizeof(ToTlmPipeName) - 1] = '\0';
 
     /*
     ** Register with EVS

--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -111,10 +111,6 @@ void TO_LAB_delete_callback(void)
 CFE_Status_t TO_LAB_init(void)
 {
     CFE_Status_t status;
-    char         PipeName[16];
-    uint16       PipeDepth;
-    char         ToTlmPipeName[16];
-    uint16       ToTlmPipeDepth;
     void        *TblPtr;
     char         VersionString[TO_LAB_CFG_MAX_VERSION_STR_LEN];
 
@@ -123,15 +119,6 @@ CFE_Status_t TO_LAB_init(void)
 
     TO_LAB_Global.AllowPassthru = true;
     TO_LAB_Global.downlink_on   = false;
-    PipeDepth                   = TO_LAB_PLATFORM_CMD_PIPE_DEPTH;
-
-    /* sizeof()-1 makes sure there's room for the null terminator when using strncpy */
-    strncpy(PipeName, "TO_LAB_CMD_PIPE", sizeof(PipeName) - 1);
-    /* Make sure a null terminator is added to the strncpy destination */
-    PipeName[sizeof(PipeName) - 1] = '\0';
-    ToTlmPipeDepth                 = TO_LAB_PLATFORM_TLM_PIPE_DEPTH;
-    strncpy(ToTlmPipeName, "TO_LAB_TLM_PIPE", sizeof(ToTlmPipeName) - 1);
-    ToTlmPipeName[sizeof(ToTlmPipeName) - 1] = '\0';
 
     /*
     ** Register with EVS
@@ -200,7 +187,7 @@ CFE_Status_t TO_LAB_init(void)
         TO_LAB_Global.SubsTblPtr = TblPtr; /* Save returned address */
 
         /* Subscribe to my commands */
-        status = CFE_SB_CreatePipe(&TO_LAB_Global.Cmd_pipe, PipeDepth, PipeName);
+        status = CFE_SB_CreatePipe(&TO_LAB_Global.Cmd_pipe, TO_LAB_PLATFORM_CMD_PIPE_DEPTH, "TO_LAB_CMD_PIPE");
         if (status != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(TO_LAB_CR_PIPE_ERR_EID,
@@ -217,7 +204,7 @@ CFE_Status_t TO_LAB_init(void)
         CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_SEND_HK_MID), TO_LAB_Global.Cmd_pipe);
 
         /* Create TO TLM pipe */
-        status = CFE_SB_CreatePipe(&TO_LAB_Global.Tlm_pipe, ToTlmPipeDepth, ToTlmPipeName);
+        status = CFE_SB_CreatePipe(&TO_LAB_Global.Tlm_pipe, TO_LAB_PLATFORM_TLM_PIPE_DEPTH, "TO_LAB_TLM_PIPE");
         if (status != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(TO_LAB_TLMPIPE_ERR_EID,


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov. (This issue was discussed in a cfs meeting. I think that counts!)

**Describe the contribution**
Static analyzer via CodeSonar found two usages of 'strcpy' in the to_lab App. Strcpy() does not check bounds and should be replaced with something that does, like strncpy(). strncpy(dest, src, sizeof(dest)-1); 
Note: When using strncpy, it’s safer to pass _sizeof(dest) - 1_ instead of _sizeof(dest)_ to reserve space for the null terminator and avoid unterminated strings.
Fixes #231 

**More Info**
Code Sonar error: BADFUNC.BO.STRCPY : Use of strcpy
Summary: A use of strcpy() or a similar function (see full list below), which are vulnerable to buffer overflows. 
Resolution: Use a function that does bounds checking, such as strncpy(), StrCbCopy(), or StrCchCopy().

The issue seems to be a concern over buffer overflow. The source string being copied over to a destination string could potentially cause issues if, for example, the source string doesn't have a null terminator for some reason. That would mean garbage could potentially be added into the destination string. 

Strncpy can add null characters, omit them, and pad them depending on the size you pass. 
If the source string is shorter than n, strncpy copies it and pads with null characters until n bytes.
If the source string length is equal to or longer than n, strncpy copies exactly n bytes with NO null terminator.
Because of this, you must always add a terminator yourself when using strncpy for string copying.

Common practice while using strncpy:
strncpy(dest, src, sizeof(dest) - 1);   //sizeof()-1 makes sure there will be room for null terminator
dest[sizeof(dest) - 1] = '\0';             //make sure the destination string has a null terminator

**Testing performed**
1. make distclean
2. make native_std.prep
3. make native_std.install
4. make native_std.runtest
5. cd build-native_std/native/default_cpu1/
6. ctest
7. Run Cosmos
8. Note: I still can't log into CodeSonar to check the static analysis results. It would be great if a reviewer could check what CodeSonar has to say.