### PR TITLE
fix: check CFE_SB_Subscribe return values in TO_LAB_init

### DIFF
--- a/fsw/src/to_lab_app.c
+++ b/fsw/src/to_lab_app.c
@@ -208,9 +208,32 @@ CFE_Status_t TO_LAB_init(void)
 
     if (status == CFE_SUCCESS)
     {
-        CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_CMD_MID), TO_LAB_Global.Cmd_pipe);
-        CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_SEND_HK_MID), TO_LAB_Global.Cmd_pipe);
+        status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_CMD_MID), TO_LAB_Global.Cmd_pipe);
+        if (status != CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(TO_LAB_SUBSCRIBE_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "L%d TO Can't subscribe to Cmd MID, status %i",
+                              __LINE__,
+                              (int)status);
+        }
+    }
 
+    if (status == CFE_SUCCESS)
+    {
+        status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_SEND_HK_MID), TO_LAB_Global.Cmd_pipe);
+        if (status != CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(TO_LAB_SUBSCRIBE_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "L%d TO Can't subscribe to HK MID, status %i",
+                              __LINE__,
+                              (int)status);
+        }
+    }
+
+    if (status == CFE_SUCCESS)
+    {
         /* Create TO TLM pipe */
         status = CFE_SB_CreatePipe(&TO_LAB_Global.Tlm_pipe, ToTlmPipeDepth, ToTlmPipeName);
         if (status != CFE_SUCCESS)


### PR DESCRIPTION
## Summary

Both `CFE_SB_Subscribe()` calls in `TO_LAB_init()` silently discard their return status. A failure means the application will not receive commands (`TO_LAB_CMD_MID`) or housekeeping requests (`TO_LAB_SEND_HK_MID`), yet it continues initialising and reports success to `CFE_ES` — making the fault invisible at startup.

Fixes #229.

## Changes

- Capture the return value of each `CFE_SB_Subscribe()` call and assign it to `status`
- Emit `TO_LAB_SUBSCRIBE_ERR_EID` on failure, matching the error-handling style used throughout the rest of `TO_LAB_init()`
- Split into two separate `if (status == CFE_SUCCESS)` blocks so a failure in the first prevents the second from masking it

## Before / After

```c
// BEFORE — return values silently ignored
CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_CMD_MID), TO_LAB_Global.Cmd_pipe);
CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_SEND_HK_MID), TO_LAB_Global.Cmd_pipe);

// AFTER — captured and reported
status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(TO_LAB_CMD_MID), TO_LAB_Global.Cmd_pipe);
if (status != CFE_SUCCESS)
    CFE_EVS_SendEvent(TO_LAB_SUBSCRIBE_ERR_EID, CFE_EVS_EventType_ERROR,
                      "L%d TO Can't subscribe to Cmd MID, status %i", __LINE__, (int)status);
```