### PR TITLE
Fix #234, Initialize SourceBufferSize in to_lab_passthru_encode.c

### DIFF
--- a/fsw/src/to_lab_passthru_encode.c
+++ b/fsw/src/to_lab_passthru_encode.c
@@ -41,7 +41,7 @@ CFE_Status_t
 TO_LAB_EncodeOutputMessage(const CFE_SB_Buffer_t *SourceBuffer, const void **DestBufferOut, size_t *DestSizeOut)
 {
     CFE_Status_t   ResultStatus;
-    CFE_MSG_Size_t SourceBufferSize;
+    CFE_MSG_Size_t SourceBufferSize = 0;
 
     ResultStatus = CFE_MSG_GetSize(&SourceBuffer->Msg, &SourceBufferSize);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/DS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #234 

**Testing performed**
GitHub Actions and CodeSonar

**Expected behavior changes**
Resolve CodeSonar warnings on uninitialized variables

**System(s) tested on**
GitHub Actions and CodeSonar. CodeSonar results will be posted on the internal ticket.

**Additional context**


**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.